### PR TITLE
Issue #19 Deviseのconfirmationを有効にする。すでに登録済みのメールアドレスはconfirm済みにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'pg', '~> 0.11'
 gem 'friendly_id'
 
 group :development do
+  gem 'dotenv-rails'
   gem 'guard'
   gem 'guard-livereload'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     elasticsearch (5.0.5)
       elasticsearch-api (= 5.0.5)
       elasticsearch-transport (= 5.0.5)
@@ -358,6 +362,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   devise!
+  dotenv-rails
   elasticsearch-model (~> 5.1.0)
   elasticsearch-rails (~> 5.1.0)
   facebox-rails

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,7 +74,6 @@ class User < ActiveRecord::Base
                     username: auth.info.name,
                     password: Devise.friendly_token[0,20]
                    )
-    user.skip_confirmation!
     user.save
     user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable,
          :omniauthable, :omniauth_providers => [:google_oauth2]
 
@@ -68,8 +68,14 @@ class User < ActiveRecord::Base
 
   def self.from_omniauth(auth)
     user = User.find_by_email(auth.info.email)
-    return user if user
+    return user if user and user.confirmed?
 
-    User.create!(email: auth.info.email, username: auth.info.name, password: Devise.friendly_token[0,20])
+    user = User.new(email: auth.info.email,
+                    username: auth.info.name,
+                    password: Devise.friendly_token[0,20]
+                   )
+    user.skip_confirmation!
+    user.save
+    user
   end
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -15,7 +15,7 @@ ja:
     failure:
       already_authenticated: 既にログインしています。
       unauthenticated: 続けるにはログインまたはアカウントを登録してください。
-      unconfirmed: 本登録を行ってください。
+      unconfirmed: アカウント確認のリンクが入っているメールを送りました。 メール内のリンクでアカウントを有効にしてください。
       locked: アカウントが凍結されています。
       invalid: メールアドレスまたはパスワードが違います。
       timeout: セッションがタイムアウトしました。もう一度ログインしてください。

--- a/db/migrate/20200819082927_add_confirmable_to_devise.rb
+++ b/db/migrate/20200819082927_add_confirmable_to_devise.rb
@@ -5,6 +5,8 @@ class AddConfirmableToDevise < ActiveRecord::Migration
     add_column :users, :confirmation_sent_at, :datetime
     add_column :users, :unconfirmed_email, :string
     add_index :users, :confirmation_token, unique: true
+
+    execute("UPDATE users SET confirmed_at = NOW()")
   end
 
   def down

--- a/db/migrate/20200819082927_add_confirmable_to_devise.rb
+++ b/db/migrate/20200819082927_add_confirmable_to_devise.rb
@@ -6,7 +6,7 @@ class AddConfirmableToDevise < ActiveRecord::Migration
     add_column :users, :unconfirmed_email, :string
     add_index :users, :confirmation_token, unique: true
 
-    execute("UPDATE users SET confirmed_at = NOW()")
+    User.all.each { |user| user.skip_confirmation! }
   end
 
   def down

--- a/db/migrate/20200819082927_add_confirmable_to_devise.rb
+++ b/db/migrate/20200819082927_add_confirmable_to_devise.rb
@@ -1,0 +1,13 @@
+class AddConfirmableToDevise < ActiveRecord::Migration
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+    add_index :users, :confirmation_token, unique: true
+  end
+
+  def down
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at, :unconfirmed_email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20200416132118) do
+ActiveRecord::Schema.define(:version => 20200819082927) do
 
   create_table "annotators", :force => true do |t|
     t.string   "name"
@@ -336,8 +336,13 @@ ActiveRecord::Schema.define(:version => 20200416132118) do
     t.datetime "updated_at",                                :null => false
     t.text     "username",               :default => "",    :null => false
     t.boolean  "root",                   :default => false
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
   end
 
+  add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true
   add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
   add_index "users", ["username"], :name => "index_users_on_username", :unique => true


### PR DESCRIPTION
#19

**対応内容**
- Deviseのconfirmationを有効にする。すでに登録済みのメールアドレスはconfirm済みとする。
- userマイグレーションにconfirm系のカラム追加
- gem（dotenv-rails）追加

**確認内容**
- ログイン画面に「Log in with Google」リンク付けてあること
- リンク押下で表示画面に、googleアカウントでログインする
- ログインしたらリダイレクトされること
-  User.confirmed_atが更新されていること

**画面**

<img width="1134" alt="スクリーンショット 2020-08-20 14 36 37" src="https://user-images.githubusercontent.com/39178089/90721238-4faeaf80-e2f3-11ea-858f-92b777dd577c.png">

<img width="1206" alt="スクリーンショット 2020-08-20 14 37 23" src="https://user-images.githubusercontent.com/39178089/90721246-53423680-e2f3-11ea-8a5c-5c9255769f92.png">

<img width="830" alt="スクリーンショット 2020-08-20 14 41 22" src="https://user-images.githubusercontent.com/39178089/90721252-56d5bd80-e2f3-11ea-9fde-c070c65aa426.png">



