### PR TITLE
issue #19 確認メールのリンク押下で本登録確定

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,10 @@
+class ConfirmationsController < Devise::ConfirmationsController
+  def show
+    resource = resource_class.find_by_confirmation_token(params[:confirmation_token])
+    return super if resource.nil? || resource.confirmed?
+
+    resource.confirm!
+    set_flash_message :notice, :confirmed
+    sign_in_and_redirect(resource)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,10 @@ Pubann::Application.routes.draw do
   resources :annotators
   resources :editors
 
-  devise_for :users, :controllers => { :omniauth_callbacks => "callbacks" }
+  devise_for :users, controllers: {
+    :omniauth_callbacks => 'callbacks',
+    :confirmations => 'confirmations'
+  }
 
   get "home/index"
 


### PR DESCRIPTION
#19 

**対応内容**
- confirmメールに記載してある本登録画面が`http://localhost:3000/users/confirmation?confirmation_token=***`のようなURLを開いて、フォームで再ログインできる修正

**確認内容**
- confirmメールに記載してあるリンク押下で、本登録（User.confirmed_atが更新されいる）できていること
- 再度、ログイン画面の「Log in with Google」リンク押下で、本登録済のため更新せずにリダイレクトされること
(routesへの追加、confirmationコントローラ追加)

**画面**

<img width="1127" alt="スクリーンショット 2020-08-24 18 39 26" src="https://user-images.githubusercontent.com/39178089/91029332-9412b600-e639-11ea-8887-dd4174a1f1a0.png">

<img width="495" alt="スクリーンショット 2020-08-24 18 39 08" src="https://user-images.githubusercontent.com/39178089/91029350-9c6af100-e639-11ea-900b-7aae07d6703c.png">

再ログイン

<img width="1353" alt="スクリーンショット 2020-08-24 18 44 45" src="https://user-images.githubusercontent.com/39178089/91030475-316dea00-e63a-11ea-8b40-d4f4719fd66f.png">

<img width="1353" alt="スクリーンショット 2020-08-24 18 45 18" src="https://user-images.githubusercontent.com/39178089/91030486-3468da80-e63a-11ea-954b-7f1e64966230.png">

<img width="1366" alt="スクリーンショット 2020-08-24 18 45 44" src="https://user-images.githubusercontent.com/39178089/91030493-3763cb00-e63a-11ea-9051-62aa90713126.png">
