### PR TITLE
issue #19 登録済ユーザのconfirm済とする

### DIFF
--- a/db/migrate/20200819082927_add_confirmable_to_devise.rb
+++ b/db/migrate/20200819082927_add_confirmable_to_devise.rb
@@ -6,10 +6,11 @@ class AddConfirmableToDevise < ActiveRecord::Migration
     add_column :users, :unconfirmed_email, :string
     add_index :users, :confirmation_token, unique: true
 
-    User.all.each { |user| user.skip_confirmation! }
+    execute "UPDATE users SET confirmed_at = NOW()"
   end
 
   def down
+    remove_index :users, :confirmation_token
     remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at, :unconfirmed_email
   end
 end


### PR DESCRIPTION
#19

**対応内容**
- 既存のBasic認証のユーザーがconfirm済みになっていないため、マイグレーション変更修正

**確認内容**

マイグレーション実行する前のconfirmed_atの確認

<img width="476" alt="スクリーンショット 2020-08-26 16 05 49" src="https://user-images.githubusercontent.com/39178089/91275438-242c3900-e7bb-11ea-852c-18ac5d6032e5.png">

ロールバック（rake db:rollback STEP=1）して、再度rake db:migrateを実行した後、confirmed_atの確認

<img width="686" alt="スクリーンショット 2020-08-26 16 36 25" src="https://user-images.githubusercontent.com/39178089/91275520-3e661700-e7bb-11ea-8fd5-535583fc0b4b.png">

