### PR TITLE
issue #19 ログイン成功したらポップアップ閉じて親ページのリロード

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,7 +1,8 @@
 class CallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
     user = User.from_omniauth(request.env["omniauth.auth"])
+    sign_in(:user, user) if user.persisted?
 
-    sign_in_and_redirect user
+    render :closed_and_reloaded, layout: false
   end
 end

--- a/app/views/callbacks/closed_and_reloaded.html.erb
+++ b/app/views/callbacks/closed_and_reloaded.html.erb
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <script>
+      window.opener.location.reload();
+      window.close();
+    </script>
+  </body>
+</html>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,10 +4,10 @@
 <% end %>
 
 <h1><%= t('views.users.sign_in') %></h1>
-<!--
+
 <div style="margin:2px"><%= link_to login_with_google.html_safe, omniauth_authorize_path(resource_name, :google_oauth2) %></div>
 <br/>
- -->
+
 <%= form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f| %>
 <table>
 <tr>


### PR DESCRIPTION
#19 

**対応内容**

- ログイン成功したらポップアップ閉じて、親ページをリロードする

**確認内容**

- ログインウィンドウからログインすると、ウィンドウが閉じられて親ウィンドウがリロードされること

**画面**

<img width="1030" alt="スクリーンショット 2020-08-31 19 26 25" src="https://user-images.githubusercontent.com/39178089/91710907-f7fc2800-ebbf-11ea-9218-35de413713d1.png">

<img width="1052" alt="スクリーンショット 2020-08-31 19 26 36" src="https://user-images.githubusercontent.com/39178089/91710915-faf71880-ebbf-11ea-8a5d-9e67e34571ba.png">
