### PR TITLE
issue #19 Basic認証でログインした後、ポップアップを閉じて元のページをリロード

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,8 @@
+class SessionsController < Devise::SessionsController
+  def create
+    user = warden.authenticate!(auth_options)
+    sign_in(:user, user) if user.persisted?
+
+    render :closed_and_reloaded, layout: false
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,6 @@ class SessionsController < Devise::SessionsController
     user = warden.authenticate!(auth_options)
     sign_in(:user, user) if user.persisted?
 
-    render :closed_and_reloaded, layout: false
+    render template: 'callbacks/closed_and_reloaded', layout: false
   end
 end

--- a/app/views/sessions/closed_and_reloaded.html.erb
+++ b/app/views/sessions/closed_and_reloaded.html.erb
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <script>
+      window.opener.location.reload();
+      window.close();
+    </script>
+  </body>
+</html>

--- a/app/views/sessions/closed_and_reloaded.html.erb
+++ b/app/views/sessions/closed_and_reloaded.html.erb
@@ -1,8 +1,0 @@
-<html>
-  <body>
-    <script>
-      window.opener.location.reload();
-      window.close();
-    </script>
-  </body>
-</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,8 @@ Pubann::Application.routes.draw do
 
   devise_for :users, controllers: {
     :omniauth_callbacks => 'callbacks',
-    :confirmations => 'confirmations'
+    :confirmations => 'confirmations',
+    :sessions => 'sessions'
   }
 
   get "home/index"


### PR DESCRIPTION
#19 

**対応内容**

- Basic認証の場合は、ログインしたらポップアップウィンドウを閉じて、元の画面をリロードする修正

**確認内容**

- Basic認証のログインで、ポップアップウィンドウが閉じられて元の画面にリロードできること。
- リロードした画面の右上にユーザ名が表示されること
- リロードした画面の右上に「ログイン」リンクが「ログアウト」リンクで表示されること

**画面**

_ユーザID/パスワードを入力してログインボタンを押下_

<img width="1261" alt="スクリーンショット 2020-09-08 10 19 44" src="https://user-images.githubusercontent.com/39178089/92423736-19ab6f80-f1bd-11ea-9537-9d1c72ab11a8.png">

_ポップアップウィンドウが閉じられて元の画面がリロードされる_

<img width="1190" alt="スクリーンショット 2020-09-08 10 20 08" src="https://user-images.githubusercontent.com/39178089/92423801-4cedfe80-f1bd-11ea-8cbd-1175c7780851.png">

