### PR TITLE
issue #27 textaeからのannotation登録時の変更修正

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 class AnnotationsController < ApplicationController
   protect_from_forgery :except => [:create]
-  before_filter :authenticate_user!, :except => [:index, :align, :doc_annotations_index, :div_annotations_index, :project_doc_annotations_index, :project_div_annotations_index, :doc_annotations_list_view, :div_annotations_list_view, :doc_annotations_merge_view, :div_annotations_merge_view, :project_annotations_tgz, :create]
+  before_filter :authenticate_user!, :except => [:create, :index, :align, :doc_annotations_index, :div_annotations_index, :project_doc_annotations_index, :project_div_annotations_index, :doc_annotations_list_view, :div_annotations_list_view, :doc_annotations_merge_view, :div_annotations_merge_view, :project_annotations_tgz]
   include DenotationsHelper
 
   def index
@@ -772,7 +772,7 @@ class AnnotationsController < ApplicationController
       raise "There is no such project." unless project.present?
 
       if File.exist?(project.annotations_rdf_system_path)
-        if project.user == current_user 
+        if project.user == current_user
           File.unlink(project.annotations_rdf_system_path)
           flash[:notice] = t('views.shared.rdf.deleted')
         else

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 class AnnotationsController < ApplicationController
   protect_from_forgery :except => [:create]
-  before_filter :authenticate_user!, :except => [:index, :align, :doc_annotations_index, :div_annotations_index, :project_doc_annotations_index, :project_div_annotations_index, :doc_annotations_list_view, :div_annotations_list_view, :doc_annotations_merge_view, :div_annotations_merge_view, :project_annotations_tgz]
+  before_filter :authenticate_user!, :except => [:index, :align, :doc_annotations_index, :div_annotations_index, :project_doc_annotations_index, :project_div_annotations_index, :doc_annotations_list_view, :div_annotations_list_view, :doc_annotations_merge_view, :div_annotations_merge_view, :project_annotations_tgz, :create]
   include DenotationsHelper
 
   def index
@@ -245,6 +245,13 @@ class AnnotationsController < ApplicationController
   # POST /annotations
   # POST /annotations.json
   def create
+    unless user_signed_in? then
+      response.headers['WWW-Authenticate'] = 'ServerPage'
+      response.headers['Location'] = new_user_session_url
+      response.headers['Access-Control-Expose-Headers'] = 'WWW-Authenticate, Location'
+      head 401 and return
+    end
+
     begin
       project = Project.editable(current_user).find_by_name(params[:project_id])
       raise "There is no such project in your management." unless project.present?

--- a/app/views/callbacks/closed_and_reloaded.html.erb
+++ b/app/views/callbacks/closed_and_reloaded.html.erb
@@ -1,8 +1,12 @@
 <html>
   <body>
     <script>
-      window.opener.location.reload();
+      window.onbeforeunload= parentReload;
       window.close();
+
+      function parentReload() {
+        window.opener.location.reload();
+      }
     </script>
   </body>
 </html>

--- a/app/views/callbacks/closed_and_reloaded.html.erb
+++ b/app/views/callbacks/closed_and_reloaded.html.erb
@@ -1,7 +1,7 @@
 <html>
   <body>
     <script>
-      window.onbeforeunload= parentReload;
+      window.onbeforeunload = parentReload;
       window.close();
 
       function parentReload() {


### PR DESCRIPTION
#27 

**対応内容**

- 未ログイン時に、textaeからの「Login is required」ウィンドウでのsaveリンク押下でログイン用のポップアップウィンドウが表示されること

- 表示されたポップアップウィンドウにてBasicまたgoogle認証でログインしたらウィンドウが閉じられ親画面をリロードできること


**確認内容**

- pubannotation側は未ログイン状態で、textaeの「Login is required」ウィンドウでのsaveリンク押下でログインする

**画面**

_ログイン前（pubannotation）_

<img width="939" alt="スクリーンショット 2020-09-11 12 22 11" src="https://user-images.githubusercontent.com/39178089/92852249-79a64e00-f429-11ea-9d91-a202511db844.png">

_ログイン前（textae）_

<img width="925" alt="スクリーンショット 2020-09-11 12 22 55" src="https://user-images.githubusercontent.com/39178089/92852388-9f335780-f429-11ea-988a-fb7db8b843ec.png">

<img width="785" alt="スクリーンショット 2020-09-11 12 23 48" src="https://user-images.githubusercontent.com/39178089/92852430-a9edec80-f429-11ea-9fd8-a7be0609e2a3.png">

saveリンク押下でpubannotationのログインウィンドウが表示される

<img width="848" alt="スクリーンショット 2020-09-11 12 24 21" src="https://user-images.githubusercontent.com/39178089/92852560-d3a71380-f429-11ea-963d-c6ffd5b62874.png">


_ログイン後（pubannotation）_

画面リフレッシュすると、ユーザ名とリンク変更（ログイン→ログアウト）が表示される

<img width="934" alt="スクリーンショット 2020-09-11 12 27 46" src="https://user-images.githubusercontent.com/39178089/92852971-431d0300-f42a-11ea-801c-10b8039e1982.png">





