### PR TITLE
issue #30 DBCLS共通ヘッダーの挿入

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,9 +21,9 @@
 			src="https://dbcls.rois.ac.jp/DBCLS-common-header-footer/v2/script/common-header-and-footer.js"
 			style="display: block"
 			id="common-header-and-footer__script"
-	    data-width="auto"
-	    data-header-menu-type="deployed"
-	    data-color="mono"
+			data-width="auto"
+			data-header-menu-type="deployed"
+			data-color="mono"
 		></script>
 		<div id="header" class="frame">
 			<div class="content">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,12 @@
 	</head>
 
 	<body>
+		<script
+			type="text/javascript"
+			src="https://dbcls.rois.ac.jp/DBCLS-common-header-footer/v2/script/common-header-and-footer.js"
+			style="display: block"
+			id="common-header-and-footer__script"
+		></script>
 		<div id="header" class="frame">
 			<div class="content">
 				<%= render :partial => 'layouts/header' -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,9 @@
 			src="https://dbcls.rois.ac.jp/DBCLS-common-header-footer/v2/script/common-header-and-footer.js"
 			style="display: block"
 			id="common-header-and-footer__script"
+	    data-width="auto"
+	    data-header-menu-type="deployed"
+	    data-color="mono"
 		></script>
 		<div id="header" class="frame">
 			<div class="content">


### PR DESCRIPTION
#30 

**対応内容**

- 標準的なDBCLS用共通ヘッダの導入しました。
　https://github.com/dbcls/website/tree/master/DBCLS-common-header-footer/v2

**確認確認**

- 画面起動でヘッダーにDBCLS用共通ヘッダが表示されること

**画面**

<img width="1073" alt="スクリーンショット 2020-09-24 19 50 40" src="https://user-images.githubusercontent.com/39178089/94136040-4e971200-fe9f-11ea-92fe-a8d499cec99d.png">
を
<img width="1139" alt="スクリーンショット 2020-09-30 10 56 25" src="https://user-images.githubusercontent.com/39178089/94634685-a7d1cc00-030b-11eb-9231-4d7ba3ce6e52.png">
に変更しました。