### PR TITLE
Fixed the process when a similar document exists when uploading a file

### DIFF
--- a/app/jobs/upload_docs_job.rb
+++ b/app/jobs/upload_docs_job.rb
@@ -61,11 +61,11 @@ class UploadDocsJob < Struct.new(:dirpath, :project, :options)
 
 				if same_doc.present?
 					if mode == :update
-						messages = same_doc.revise(hdoc[:body])
+						error_messages = same_doc.revise(hdoc)
 						if @job
-							messages.each{|m| @job.messages << Message.create({sourcedb:same_doc.sourcedb, sourceid:same_doc.sourceid, body:m})}
-						else
-							raise messages.join("\n")
+							error_messages.each{|m| @job.messages << Message.create({sourcedb:same_doc.sourcedb, sourceid:same_doc.sourceid, body:m})}
+						elsif error_messages.present?
+							raise error_messages.join("\n")
 						end
 					end
 					num_updated_or_skipped += 1

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -329,7 +329,7 @@ class Doc < ActiveRecord::Base
 
 	def revise(new_hdoc)
 		messages = []
-		new_body = new_hdoc[:text]
+		new_body = new_hdoc[:text] || new_hdoc[:body]
 
 		if new_body == self.body
 			unless self.divisions == new_hdoc[:divisions]


### PR DESCRIPTION
## Purpose
Fixed a bug that the document is not updated under the conditions of "Check UPDATE the existing one", "There is a document with the same sourcedb and sourceid" and "File less than 100 kilobytes" when uploading the document.

## ChangeList
- Changed the conditions to raise an exception in `upload_docs_job.rb`
- Changed revise method to support document updates