### PR TITLE
Changed to use DelayedJob as backend queue adapter for ActiveJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,40 @@
+class ApplicationJob < ActiveJob::Base
+  def create_job_record(organization_jobs, job_name)
+    delayed_job = Delayed::Job.find(self.provider_job_id)
+    organization_jobs.create({ name: job_name, active_job_id: self.job_id, delayed_job_id: delayed_job.id })
+  end
+
+  rescue_from(StandardError) do |exception|
+    if @job
+      @job.messages << Message.create({sourcedb: '*', sourceid: '*', divid: nil, body: exception.message})
+      set_ended_at
+    end
+    raise exception
+  end
+
+  before_perform do |active_job|
+    if set_job(active_job)
+      set_begun_at
+    end
+  end
+
+  after_perform do
+    if @job
+      set_ended_at
+    end
+  end
+
+  private
+
+  def set_job(active_job)
+    @job = Job.find_by(active_job_id: active_job.job_id)
+  end
+
+  def set_begun_at
+    @job.update_attribute(:begun_at, Time.now)
+  end
+
+  def set_ended_at
+    @job.update_attribute(:ended_at, Time.now)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,5 +79,8 @@ module Pubann
 
     config.system_path_rdf = "#{Rails.root}/db/rdf/"
     config.project_indexable_max_docs = 200000
+
+    # Setting the queuing backend used by ActiveJob
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -3,3 +3,7 @@ Delayed::Worker.max_attempts = 1
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_run_time = 14.days
 Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+Delayed::Worker.queue_attributes = {
+  general: { priority: 0 },
+  low_priority: { priority: 10 }
+}

--- a/db/migrate/20210610074419_add_active_job_id_column_to_jobs.rb
+++ b/db/migrate/20210610074419_add_active_job_id_column_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddActiveJobIdColumnToJobs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :jobs, :active_job_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_06_064827) do
+ActiveRecord::Schema.define(version: 2021_06_10_074419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,6 +198,7 @@ ActiveRecord::Schema.define(version: 2021_06_06_064827) do
     t.datetime "ended_at"
     t.datetime "registered_at"
     t.string "organization_type"
+    t.string "active_job_id"
     t.index ["delayed_job_id"], name: "index_jobs_on_delayed_job_id"
     t.index ["organization_id"], name: "index_jobs_on_organization_id"
   end


### PR DESCRIPTION
## Purpose
Prepare to switch the backend job execution environment to ActiveJob + DelayedJob.

## Change List
- Added active_job_id column to Jobs table
- Set DelayedJob as queuing backend
- Define a new queue called low_priority and set priority
- Created ApplicationJob and migrated the contents of state_management.rb