### PR TITLE
Added Rails version information to migration file

### DIFF
--- a/db/migrate/20160706062835_create_tables.rb
+++ b/db/migrate/20160706062835_create_tables.rb
@@ -1,4 +1,4 @@
-class CreateTables < ActiveRecord::Migration
+class CreateTables < ActiveRecord::Migration[4.2]
   if ActiveRecord::Base.connection.table_exists?('associate_projects_projects')
     drop_table :associate_projects_projects
   end

--- a/db/migrate/20160713093746_create_news_notifications.rb
+++ b/db/migrate/20160713093746_create_news_notifications.rb
@@ -1,4 +1,4 @@
-class CreateNewsNotifications < ActiveRecord::Migration
+class CreateNewsNotifications < ActiveRecord::Migration[4.2]
   def up
     create_table :news_notifications do |t|
       t.string :title

--- a/db/migrate/20160916063207_counters_to_numbers.rb
+++ b/db/migrate/20160916063207_counters_to_numbers.rb
@@ -1,4 +1,4 @@
-class CountersToNumbers < ActiveRecord::Migration
+class CountersToNumbers < ActiveRecord::Migration[4.2]
   def up
   	change_table :projects do |t|
   		t.rename :denotations_count, :denotations_num

--- a/db/migrate/20160926023030_delta_to_flag.rb
+++ b/db/migrate/20160926023030_delta_to_flag.rb
@@ -1,4 +1,4 @@
-class DeltaToFlag < ActiveRecord::Migration
+class DeltaToFlag < ActiveRecord::Migration[4.2]
   def up
   	change_table :docs do |t|
   		t.remove :delta

--- a/db/migrate/20160927033635_projects_count_to_num.rb
+++ b/db/migrate/20160927033635_projects_count_to_num.rb
@@ -1,4 +1,4 @@
-class ProjectsCountToNum < ActiveRecord::Migration
+class ProjectsCountToNum < ActiveRecord::Migration[4.2]
   def up
   	change_table :docs do |t|
   		t.rename :projects_count, :projects_num

--- a/db/migrate/20170202141841_create_project_docs.rb
+++ b/db/migrate/20170202141841_create_project_docs.rb
@@ -1,4 +1,4 @@
-class CreateProjectDocs < ActiveRecord::Migration
+class CreateProjectDocs < ActiveRecord::Migration[4.2]
   def up
     create_table :project_docs do |t|
     	t.belongs_to :project

--- a/db/migrate/20170204075835_add_numbers_to_doc.rb
+++ b/db/migrate/20170204075835_add_numbers_to_doc.rb
@@ -1,4 +1,4 @@
-class AddNumbersToDoc < ActiveRecord::Migration
+class AddNumbersToDoc < ActiveRecord::Migration[4.2]
   def up
   	change_table :docs do |t|
   		t.rename :denotations_count, :denotations_num

--- a/db/migrate/20170213023156_add_index_for_project_docs.rb
+++ b/db/migrate/20170213023156_add_index_for_project_docs.rb
@@ -1,4 +1,4 @@
-class AddIndexForProjectDocs < ActiveRecord::Migration
+class AddIndexForProjectDocs < ActiveRecord::Migration[4.2]
   def up
     add_index :docs, :denotations_num
     add_index :project_docs, :doc_id

--- a/db/migrate/20170221123628_remove_url2_from_annotator.rb
+++ b/db/migrate/20170221123628_remove_url2_from_annotator.rb
@@ -1,4 +1,4 @@
-class RemoveUrl2FromAnnotator < ActiveRecord::Migration
+class RemoveUrl2FromAnnotator < ActiveRecord::Migration[4.2]
   def up
   	change_table :annotators do |t|
   		t.remove :url2, :params2, :method2

--- a/db/migrate/20170325101038_remove_abbrev_from_annotator.rb
+++ b/db/migrate/20170325101038_remove_abbrev_from_annotator.rb
@@ -1,4 +1,4 @@
-class RemoveAbbrevFromAnnotator < ActiveRecord::Migration
+class RemoveAbbrevFromAnnotator < ActiveRecord::Migration[4.2]
   def up
    	change_table :annotators do |t|
   		t.remove :abbrev

--- a/db/migrate/20170325101327_rename_params_to_payload.rb
+++ b/db/migrate/20170325101327_rename_params_to_payload.rb
@@ -1,4 +1,4 @@
-class RenameParamsToPayload < ActiveRecord::Migration
+class RenameParamsToPayload < ActiveRecord::Migration[4.2]
   def up
    	change_table :annotators do |t|
   		t.rename :params, :payload

--- a/db/migrate/20170327051248_add_batch_num_to_annotators.rb
+++ b/db/migrate/20170327051248_add_batch_num_to_annotators.rb
@@ -1,4 +1,4 @@
-class AddBatchNumToAnnotators < ActiveRecord::Migration
+class AddBatchNumToAnnotators < ActiveRecord::Migration[4.2]
   def up
   	change_table :annotators do |t|
   		t.integer :batch_num, default: 1

--- a/db/migrate/20170404051809_add_is_public_to_annotator.rb
+++ b/db/migrate/20170404051809_add_is_public_to_annotator.rb
@@ -1,4 +1,4 @@
-class AddIsPublicToAnnotator < ActiveRecord::Migration
+class AddIsPublicToAnnotator < ActiveRecord::Migration[4.2]
   def up
   	change_table :annotators do |t|
   		t.boolean :is_public, default: false

--- a/db/migrate/20170408044405_create_editors.rb
+++ b/db/migrate/20170408044405_create_editors.rb
@@ -1,4 +1,4 @@
-class CreateEditors < ActiveRecord::Migration
+class CreateEditors < ActiveRecord::Migration[4.2]
   def change
     create_table :editors do |t|
       t.string :name

--- a/db/migrate/20170415043109_create_sequencers.rb
+++ b/db/migrate/20170415043109_create_sequencers.rb
@@ -1,4 +1,4 @@
-class CreateSequencers < ActiveRecord::Migration
+class CreateSequencers < ActiveRecord::Migration[4.2]
   def change
     create_table :sequencers do |t|
       t.string :name

--- a/db/migrate/20170708102542_rename_editor_to_textae_config.rb
+++ b/db/migrate/20170708102542_rename_editor_to_textae_config.rb
@@ -1,4 +1,4 @@
-class RenameEditorToTextaeConfig < ActiveRecord::Migration
+class RenameEditorToTextaeConfig < ActiveRecord::Migration[4.2]
   def up
    	change_table :projects do |t|
   		t.remove :editor

--- a/db/migrate/20171008033045_create_queries.rb
+++ b/db/migrate/20171008033045_create_queries.rb
@@ -1,4 +1,4 @@
-class CreateQueries < ActiveRecord::Migration
+class CreateQueries < ActiveRecord::Migration[4.2]
   def change
     create_table :queries do |t|
       t.string :title, default: "", nul: false

--- a/db/migrate/20180118124715_add_type_to_query.rb
+++ b/db/migrate/20180118124715_add_type_to_query.rb
@@ -1,4 +1,4 @@
-class AddTypeToQuery < ActiveRecord::Migration
+class AddTypeToQuery < ActiveRecord::Migration[4.2]
   def up
   	change_table :queries do |t|
   		t.integer :category, default:2

--- a/db/migrate/20180123053557_add_reasoning_to_query.rb
+++ b/db/migrate/20180123053557_add_reasoning_to_query.rb
@@ -1,4 +1,4 @@
-class AddReasoningToQuery < ActiveRecord::Migration
+class AddReasoningToQuery < ActiveRecord::Migration[4.2]
   def change
     add_column :queries, :reasoning, :boolean, default: false
   end

--- a/db/migrate/20190308175443_create_collections.rb
+++ b/db/migrate/20190308175443_create_collections.rb
@@ -1,4 +1,4 @@
-class CreateCollections < ActiveRecord::Migration
+class CreateCollections < ActiveRecord::Migration[4.2]
   def change
     create_table :collections do |t|
       t.string :name

--- a/db/migrate/20190308180850_create_collection_projects.rb
+++ b/db/migrate/20190308180850_create_collection_projects.rb
@@ -1,4 +1,4 @@
-class CreateCollectionProjects < ActiveRecord::Migration
+class CreateCollectionProjects < ActiveRecord::Migration[4.2]
   def change
     create_table :collection_projects do |t|
     	t.belongs_to :collection

--- a/db/migrate/20190404064112_create_evaluators.rb
+++ b/db/migrate/20190404064112_create_evaluators.rb
@@ -1,4 +1,4 @@
-class CreateEvaluators < ActiveRecord::Migration
+class CreateEvaluators < ActiveRecord::Migration[4.2]
   def change
     create_table :evaluators do |t|
       t.string :name

--- a/db/migrate/20190404074547_create_evaluations.rb
+++ b/db/migrate/20190404074547_create_evaluations.rb
@@ -1,4 +1,4 @@
-class CreateEvaluations < ActiveRecord::Migration
+class CreateEvaluations < ActiveRecord::Migration[4.2]
   def change
     create_table :evaluations do |t|
       t.references :study_project

--- a/db/migrate/20190501042525_add_parameters_to_evaluation.rb
+++ b/db/migrate/20190501042525_add_parameters_to_evaluation.rb
@@ -1,4 +1,4 @@
-class AddParametersToEvaluation < ActiveRecord::Migration
+class AddParametersToEvaluation < ActiveRecord::Migration[4.2]
   def change
     add_column :evaluations, :soft_match_characters, :integer
     add_column :evaluations, :soft_match_words, :integer

--- a/db/migrate/20190815001316_add_sample_to_annotator.rb
+++ b/db/migrate/20190815001316_add_sample_to_annotator.rb
@@ -1,4 +1,4 @@
-class AddSampleToAnnotator < ActiveRecord::Migration
+class AddSampleToAnnotator < ActiveRecord::Migration[4.2]
   def change
     add_column :annotators, :sample, :text
   end

--- a/db/migrate/20200125033354_add_active_to_news_notifications.rb
+++ b/db/migrate/20200125033354_add_active_to_news_notifications.rb
@@ -1,4 +1,4 @@
-class AddActiveToNewsNotifications < ActiveRecord::Migration
+class AddActiveToNewsNotifications < ActiveRecord::Migration[4.2]
   def change
     add_column :news_notifications, :active, :boolean, default: false
   end

--- a/db/migrate/20200125152948_create_attributes.rb
+++ b/db/migrate/20200125152948_create_attributes.rb
@@ -1,4 +1,4 @@
-class CreateAttributes < ActiveRecord::Migration
+class CreateAttributes < ActiveRecord::Migration[4.2]
 	def change
 		# 'attributes' is renamed to 'attrivute' to avoid conflict with the reserved word 'attributes'
 		create_table :attrivutes do |t|

--- a/db/migrate/20200401031734_change_batch_num_to_max_size.rb
+++ b/db/migrate/20200401031734_change_batch_num_to_max_size.rb
@@ -1,4 +1,4 @@
-class ChangeBatchNumToMaxSize < ActiveRecord::Migration
+class ChangeBatchNumToMaxSize < ActiveRecord::Migration[4.2]
   def up
    	change_table :annotators do |t|
   		t.integer :max_text_size

--- a/db/migrate/20200413080831_add_is_open_to_collections.rb
+++ b/db/migrate/20200413080831_add_is_open_to_collections.rb
@@ -1,4 +1,4 @@
-class AddIsOpenToCollections < ActiveRecord::Migration
+class AddIsOpenToCollections < ActiveRecord::Migration[4.2]
   def up
   	change_table :collections do |t|
   		t.boolean :is_open, default: false

--- a/db/migrate/20200416132118_add_attribute_label_to_annotator.rb
+++ b/db/migrate/20200416132118_add_attribute_label_to_annotator.rb
@@ -1,4 +1,4 @@
-class AddAttributeLabelToAnnotator < ActiveRecord::Migration
+class AddAttributeLabelToAnnotator < ActiveRecord::Migration[4.2]
 	def change
 		add_column :annotators, :receiver_attribute, :string
 		add_column :annotators, :new_label, :string

--- a/db/migrate/20200818055109_create_divisions.rb
+++ b/db/migrate/20200818055109_create_divisions.rb
@@ -1,4 +1,4 @@
-class CreateDivisions < ActiveRecord::Migration
+class CreateDivisions < ActiveRecord::Migration[4.2]
 	def change
 		create_table :divisions do |t|
 			t.belongs_to :doc

--- a/db/migrate/20200819082927_add_confirmable_to_devise.rb
+++ b/db/migrate/20200819082927_add_confirmable_to_devise.rb
@@ -1,4 +1,4 @@
-class AddConfirmableToDevise < ActiveRecord::Migration
+class AddConfirmableToDevise < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :confirmation_token, :string
     add_column :users, :confirmed_at, :datetime

--- a/db/migrate/20200821103832_create_typesettings.rb
+++ b/db/migrate/20200821103832_create_typesettings.rb
@@ -1,4 +1,4 @@
-class CreateTypesettings < ActiveRecord::Migration
+class CreateTypesettings < ActiveRecord::Migration[4.2]
 	def change
 		create_table :typesettings do |t|
 			t.belongs_to :doc

--- a/db/migrate/20200831051109_add_is_public_to_sequencers.rb
+++ b/db/migrate/20200831051109_add_is_public_to_sequencers.rb
@@ -1,4 +1,4 @@
-class AddIsPublicToSequencers < ActiveRecord::Migration
+class AddIsPublicToSequencers < ActiveRecord::Migration[4.2]
   def change
     add_column :sequencers, :is_public, :boolean, default: false
   end

--- a/db/migrate/20201004121204_add_data_to_message.rb
+++ b/db/migrate/20201004121204_add_data_to_message.rb
@@ -1,4 +1,4 @@
-class AddDataToMessage < ActiveRecord::Migration
+class AddDataToMessage < ActiveRecord::Migration[4.2]
   def change
     add_column :messages, :data, :text
   end

--- a/db/migrate/20201202081620_add_annotator_ref_to_project.rb
+++ b/db/migrate/20201202081620_add_annotator_ref_to_project.rb
@@ -1,4 +1,4 @@
-class AddAnnotatorRefToProject < ActiveRecord::Migration
+class AddAnnotatorRefToProject < ActiveRecord::Migration[4.2]
 	def up
 		change_table :projects do |t|
 			t.references :annotator, index: true

--- a/db/migrate/20201221082717_add_annotations_updated_at_to_project_docs.rb
+++ b/db/migrate/20201221082717_add_annotations_updated_at_to_project_docs.rb
@@ -1,4 +1,4 @@
-class AddAnnotationsUpdatedAtToProjectDocs < ActiveRecord::Migration
+class AddAnnotationsUpdatedAtToProjectDocs < ActiveRecord::Migration[4.2]
 	def change
 		add_column :project_docs, :annotations_updated_at, :datetime
 	end

--- a/db/migrate/20210119101837_add_manager_to_user.rb
+++ b/db/migrate/20210119101837_add_manager_to_user.rb
@@ -1,4 +1,4 @@
-class AddManagerToUser < ActiveRecord::Migration
+class AddManagerToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :manager, :boolean, default: false
   end

--- a/db/migrate/20210203161056_remove_unnecessary_fields_from_projects.rb
+++ b/db/migrate/20210203161056_remove_unnecessary_fields_from_projects.rb
@@ -1,4 +1,4 @@
-class RemoveUnnecessaryFieldsFromProjects < ActiveRecord::Migration
+class RemoveUnnecessaryFieldsFromProjects < ActiveRecord::Migration[4.2]
 	def up
 		change_table :projects do |t|
 			t.rename :pmdocs_count, :docs_count

--- a/db/migrate/20210206020919_add_indices_for_divisions_and_typesettings.rb
+++ b/db/migrate/20210206020919_add_indices_for_divisions_and_typesettings.rb
@@ -1,4 +1,4 @@
-class AddIndicesForDivisionsAndTypesettings < ActiveRecord::Migration
+class AddIndicesForDivisionsAndTypesettings < ActiveRecord::Migration[4.2]
 	def change
 		add_index :divisions, :doc_id
 		add_index :typesettings, :doc_id

--- a/db/migrate/20210310180050_add_sourcedb_source_id_index_to_doc.rb
+++ b/db/migrate/20210310180050_add_sourcedb_source_id_index_to_doc.rb
@@ -1,4 +1,4 @@
-class AddSourcedbSourceIdIndexToDoc < ActiveRecord::Migration
+class AddSourcedbSourceIdIndexToDoc < ActiveRecord::Migration[4.2]
   def change
   	add_index :docs, [:sourcedb, :sourceid], unique: true
   end

--- a/db/migrate/20210512101528_add_is_block_to_denotations.rb
+++ b/db/migrate/20210512101528_add_is_block_to_denotations.rb
@@ -1,4 +1,4 @@
-class AddIsBlockToDenotations < ActiveRecord::Migration
+class AddIsBlockToDenotations < ActiveRecord::Migration[4.2]
   def change
     add_column :denotations, :is_block, :boolean, default: false
   end

--- a/db/migrate/20210513112441_add_sparql_ep_to_projects.rb
+++ b/db/migrate/20210513112441_add_sparql_ep_to_projects.rb
@@ -1,4 +1,4 @@
-class AddSparqlEpToProjects < ActiveRecord::Migration
+class AddSparqlEpToProjects < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :sparql_ep, :string
   end

--- a/db/migrate/20210513112843_add_sparql_ep_to_collections.rb
+++ b/db/migrate/20210513112843_add_sparql_ep_to_collections.rb
@@ -1,4 +1,4 @@
-class AddSparqlEpToCollections < ActiveRecord::Migration
+class AddSparqlEpToCollections < ActiveRecord::Migration[4.2]
   def change
     add_column :collections, :sparql_ep, :string
   end

--- a/db/migrate/20210513145258_rename_project_id_to_organization_id.rb
+++ b/db/migrate/20210513145258_rename_project_id_to_organization_id.rb
@@ -1,4 +1,4 @@
-class RenameProjectIdToOrganizationId < ActiveRecord::Migration
+class RenameProjectIdToOrganizationId < ActiveRecord::Migration[4.2]
 	def up
 		change_table :jobs do |t|
 			t.rename :project_id, :organization_id

--- a/db/migrate/20210517163020_add_index_for_messages.rb
+++ b/db/migrate/20210517163020_add_index_for_messages.rb
@@ -1,4 +1,4 @@
-class AddIndexForMessages < ActiveRecord::Migration
+class AddIndexForMessages < ActiveRecord::Migration[4.2]
 	def change
 		add_index :messages, [:job_id, :created_at]
 	end

--- a/db/migrate/20210521012902_add_is_primary_to_collection_projects.rb
+++ b/db/migrate/20210521012902_add_is_primary_to_collection_projects.rb
@@ -1,4 +1,4 @@
-class AddIsPrimaryToCollectionProjects < ActiveRecord::Migration
+class AddIsPrimaryToCollectionProjects < ActiveRecord::Migration[4.2]
   def change
     add_column :collection_projects, :is_primary, :boolean, default: false
   end

--- a/db/migrate/20210606064827_change_project_reference_to_organization_reference_query.rb
+++ b/db/migrate/20210606064827_change_project_reference_to_organization_reference_query.rb
@@ -1,4 +1,4 @@
-class ChangeProjectReferenceToOrganizationReferenceQuery < ActiveRecord::Migration
+class ChangeProjectReferenceToOrganizationReferenceQuery < ActiveRecord::Migration[4.2]
 	def up
 		change_table :queries do |t|
 			t.rename :project_id, :organization_id


### PR DESCRIPTION
## Purpose
Starting with Rails 5.0, Rails version information is included in the created migration file.
Since Rails5.1, version information is required, so add version information to the existing migration file.

## Change List
- Added Rails version information to migration files created before Rails 4.2.
  - In addition, specify [4.2] for all migration files created before Rails 4.2.