### PR TITLE
Fixed a bug that fragment cache is not updated

### DIFF
--- a/app/views/docs/sourcedb_in_project.html.erb
+++ b/app/views/docs/sourcedb_in_project.html.erb
@@ -11,7 +11,7 @@
 		<%= t('views.docs.sourcedb_list')-%>
 	</h1>
 
-	<% cache "sourcedb_counts_in_#{@project.name}" do -%>
+	<% cache "sourcedb_counts_in_#{@project.name}", skip_digest: true do -%>
 		<%= render :partial => "docs/sourcedb_counts" -%>
 	<% end %>
 </section>

--- a/app/views/docs/sourcedb_index.html.erb
+++ b/app/views/docs/sourcedb_index.html.erb
@@ -20,7 +20,7 @@
 		cache_key += "_#{@project.name}" if @project
 	%>
 
-	<% cache cache_key do -%>
+	<% cache cache_key, skip_digest: true do -%>
 		<%= render :partial => "docs/sourcedb_counts" -%>
 	<% end %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -10,7 +10,7 @@
 			<%= link_to t('activerecord.models.doc').pluralize.capitalize.html_safe, docs_path -%>
 			<%= render partial: 'docs/search_form', locals: {path: docs_path} -%>
 		</h1>
-		<% cache 'sourcedb_counts' do -%>
+		<% cache 'sourcedb_counts', skip_digest: true do -%>
 			<%= render :partial => "docs/sourcedb_counts" -%>
 		<% end %>
 	</section>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -77,7 +77,7 @@
 		<%= t('activerecord.models.doc').pluralize.capitalize %>
 	</legend>
 
-		<% cache("sourcedb_counts_#{@project.name}") do -%>
+		<% cache("sourcedb_counts_#{@project.name}", skip_digest: true) do -%>
 			<%= render :partial => "docs/sourcedb_counts" -%>
 		<% end %>
 


### PR DESCRIPTION
## Purpose
Fixed a bug that cache is not updated for partials using fragment cache.
Due to the effect of Cache Digests added in Rails 4.0, it is no longer possible to delete the cache with the expire_fragment method.

## Change List
- Added `skip_digest: true` option to cache method in view