### PR TITLE
Delete unnecessary column description from schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_10_074419) do
+ActiveRecord::Schema.define(version: 2021_06_06_064827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,7 +198,6 @@ ActiveRecord::Schema.define(version: 2021_06_10_074419) do
     t.datetime "ended_at"
     t.datetime "registered_at"
     t.string "organization_type"
-    t.string "active_job_id"
     t.index ["delayed_job_id"], name: "index_jobs_on_delayed_job_id"
     t.index ["organization_id"], name: "index_jobs_on_organization_id"
   end


### PR DESCRIPTION
## Purpose
Delete the description of the column that does not exist yet because it was mixed in schema.rb.