### PR TITLE
Downgrade thor to 0.20.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem 'rails-observers'
 gem 'diff-lcs'
 gem 'listen'
 gem 'spring-watcher-listen'
+gem 'thor', '~> 0.20.3'
 
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ GEM
     text_alignment (0.11.10)
       ruby-dictionary (~> 1.1, >= 1.1.1)
       string-similarity (~> 2.1)
-    thor (1.1.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (1.2.9)
@@ -397,6 +397,7 @@ DEPENDENCIES
   stardog-rb!
   tao_rdfizer (~> 0.11.3)
   text_alignment (= 0.11.10)
+  thor (~> 0.20.3)
   uglifier
   unicorn
   web-console


### PR DESCRIPTION
## Purpose
Downgrade the thor version to 0.20.3 to issue a deprecated warning if the version is 1.0 or higher.