### PR TITLE
Remove dependency on DelayedJob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'diff-lcs'
 gem 'listen'
 gem 'spring-watcher-listen'
 gem 'thor', '~> 0.20.3'
+gem 'activejob-cancel'
 
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,9 @@ GEM
     activejob (5.2.6)
       activesupport (= 5.2.6)
       globalid (>= 0.3.6)
+    activejob-cancel (0.3.1)
+      activejob (>= 4.2.0)
+      activesupport (>= 4.2.0)
     activemodel (5.2.6)
       activesupport (= 5.2.6)
     activerecord (5.2.6)
@@ -357,6 +360,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activejob-cancel
   activerecord-import
   backup
   bootsnap (>= 1.1.0)

--- a/app/helpers/annotations_helper.rb
+++ b/app/helpers/annotations_helper.rb
@@ -75,40 +75,6 @@ module AnnotationsHelper
 		return denotations
 	end
 
-	def project_annotations_rdf_link_helper(project)
-		if project.annotations_zip_downloadable == true && project.rdfwriter.present?
-			file_path = project.annotations_rdf_system_path
-			
-			if File.exist?(file_path) == true
-				rdf_created_at = File.ctime(file_path)
-				# when ZIP file exists 
-				html = link_to "Download '#{project.annotations_rdf_filename}'", project_annotations_rdf_path(project.name), :class => 'button'
-				html += content_tag :span, "#{rdf_created_at.strftime("#{t('controllers.shared.created_at')}:%Y-%m-%d %T")}", :class => 'rdf_time_stamp'
-				if rdf_created_at < project.annotations_updated_at
-					html += link_to t('controllers.annotations.update_rdf'), project_create_annotations_rdf_path(project.name, :update => true), :class => 'button', :style => "margin-left: 0.5em", :confirm => t('controllers.annotations.confirm_create_rdf')
-				end
-				if project.user == current_user
-					html += link_to t('views.shared.delete'), project_delete_annotations_rdf_path(project.name), confirm: t('controllers.shared.confirm_delete'), :class => 'button'
-				end
-				html
-			else
-				# when ZIP file deos not exists 
-				delayed_job_tasks = ActiveRecord::Base.connection.execute('SELECT * FROM delayed_jobs').select{|delayed_job| delayed_job['handler'].include?(project.name) && delayed_job['handler'].include?('create_annotations_rdf')}
-				if project.user == current_user
-					if delayed_job_tasks.blank?
-						# when delayed_job exists
-						link_to t('controllers.annotations.create_rdf'), project_create_annotations_rdf_path(project.name), :class => 'button', :confirm => t('controllers.annotations.confirm_create_rdf')
-					else
-						# delayed_job does not exists
-						t('views.shared.rdf.delayed_job_present')
-					end
-				else
-					t('views.shared.rdf.download_not_available')
-				end
-			end    
-		end    
-	end
-
 	def annotations_obtain_path
 		if params[:sourceid].present?
 			if params[:begin].present?

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,7 @@
 class ApplicationJob < ActiveJob::Base
   def create_job_record(organization_jobs, job_name)
     delayed_job = Delayed::Job.find(self.provider_job_id)
-    organization_jobs.create({ name: job_name, active_job_id: self.job_id, delayed_job_id: delayed_job.id })
+    organization_jobs.create({ name: job_name, active_job_id: self.job_id, delayed_job_id: delayed_job.id, queue_name: self.queue_name })
   end
 
   rescue_from(StandardError) do |exception|

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -53,15 +53,6 @@ class Job < ActiveRecord::Base
 		end
 	end
 
-	def scan
-		dj = begin
-			Delayed::Job.find(self.delayed_job_id)
-		rescue
-			nil
-		end
-		update_attribute(:ended_at, Time.now) if dj.nil?
-	end
-
 	def stop_if_running
 		if running?
 			dj = begin
@@ -75,17 +66,6 @@ class Job < ActiveRecord::Base
 				`script/delayed_job -i #{worker_id} restart`
 				update_attribute(:ended_at, Time.now)
 			end
-		end
-	end
-
-	def update_related_priority
-		organization.jobs.waiting.order(:created_at).each_with_index do |j, i|
-			dj = begin
-				Delayed::Job.find(j.delayed_job_id)
-			rescue
-				nil
-			end
-			dj.update_attribute(:priority, i) unless dj.nil?
 		end
 	end
 end

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -11,7 +11,7 @@
 			link_to('jobs', collection_jobs_path(@organization.name))
 		end
 	%>
-	> <%= @job.delayed_job_id %>
+	> <%= @job.id %>
 <% end %>
 
 <section>
@@ -27,7 +27,7 @@
 
 	<section>
 		<h1>
-		Job #<%= @job.delayed_job_id %>: <%= @job.name %>
+		Job #<%= @job.id %>: <%= @job.name %>
 		<%=
 			unless @job.running?
 				organization_job_path = if params.has_key? :project_id

--- a/db/migrate/20210625040838_add_queue_name_column_to_jobs.rb
+++ b/db/migrate/20210625040838_add_queue_name_column_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddQueueNameColumnToJobs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :jobs, :queue_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_10_074419) do
+ActiveRecord::Schema.define(version: 2021_06_25_040838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -199,6 +199,7 @@ ActiveRecord::Schema.define(version: 2021_06_10_074419) do
     t.datetime "registered_at"
     t.string "organization_type"
     t.string "active_job_id"
+    t.string "queue_name"
     t.index ["delayed_job_id"], name: "index_jobs_on_delayed_job_id"
     t.index ["organization_id"], name: "index_jobs_on_organization_id"
   end


### PR DESCRIPTION
## Purpose
Revise the code that depends on DelayedJob in preparation for switching the queuing backend to Sidekiq.

## Change List
- Added activejob-cancel
  - https://github.com/y-yagi/activejob-cancel
- Added queue_name column
  - The name of the queue is required when deleting a queued job with activejob-cancel.
- Revised code that depends on Delayed Job
  - However, the stop_if_running method of job.rb will be revised after migrating to Sidekiq. 
