### PR TITLE
Removed process to convert payload to string when annotator save fails

### DIFF
--- a/app/controllers/annotators_controller.rb
+++ b/app/controllers/annotators_controller.rb
@@ -80,7 +80,6 @@ class AnnotatorsController < ApplicationController
 				format.json { render json: @annotator, status: :created, location: @annotator }
 			else
 				format.html {
-					@annotator.payload = @annotator.payload_to_string
 					render action: "new"
 				}
 				format.json { render json: @annotator.errors, status: :unprocessable_entity }
@@ -104,7 +103,6 @@ class AnnotatorsController < ApplicationController
 				format.json { head :no_content }
 			else
 				format.html {
-					@annotator.payload = @annotator.payload_to_string
 					render action: "edit"
 				}
 				format.json { render json: @annotator.errors, status: :unprocessable_entity }


### PR DESCRIPTION
## Purpose
If saving fails when creating/updating Annotator, `ActiveRecord::SerializationTypeMismatch` will occur, so delete unnecessary processing.

## Change List
- Revised the processing of create action and update action of annotators_controller
  - Removed process to convert payload to string when save fails.
  - The conversion of payload to string is done in the view file.