### PR TITLE
Execute create_job_record in before_enqueue callback (modified)

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -243,14 +243,13 @@ class AnnotationsController < ApplicationController
 
 		text = doc.get_text(options[:span])
 		message = if text.length < Annotator::MaxTextSync
-			# ObtainDocAnnotationsJob.perform_now(annotator, project, doc.id, options.merge(debug: true))
-			ObtainDocAnnotationsJob.perform_now(annotator, project, doc.id, options)
+			# ObtainDocAnnotationsJob.perform_now(project, doc.id, annotator, options.merge(debug: true))
+			ObtainDocAnnotationsJob.perform_now(project, doc.id, annotator, options)
 			"Annotations were successfully obtained."
 		else
-			# ObtainDocAnnotationsJob.perform_now(annotator, project, doc.id, options)
-			# active_job = ObtainDocAnnotationsJob.perform_later(annotator, project, doc.id, options.merge(debug: true))
-			active_job = ObtainDocAnnotationsJob.perform_later(annotator, project, doc.id, options)
-			active_job.create_job_record(project.jobs, "Obtain annotations for a document: #{annotator.name}")
+			# ObtainDocAnnotationsJob.perform_now(project, doc.id, annotator, options)
+			# ObtainDocAnnotationsJob.perform_later(project, doc.id, annotator, options.merge(debug: true))
+			ObtainDocAnnotationsJob.perform_later(project, doc.id, annotator, options)
 			"A background job was created to obtain annotations."
 		end
 

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -476,8 +476,7 @@ class AnnotationsController < ApplicationController
 
 			docids = shared_docs.collect{|d| d.id}
 
-			active_job = ImportAnnotationsJob.perform_later(source_project, project)
-			active_job.create_job_record(project.jobs, "Import annotations from #{source_project.name}")
+			ImportAnnotationsJob.perform_later(project, source_project)
 			message = "The task, 'import annotations from the project, #{source_project.name}', is created."
 
 		rescue => e

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -499,9 +499,8 @@ class AnnotationsController < ApplicationController
 			# CreateAnnotationsTgzJob.perform_now(project, {})
 
 			active_job = CreateAnnotationsTgzJob.perform_later(project, {})
-			active_job.create_job_record(project.jobs, 'Create a downloadable archive')
 
-			redirect_back fallback_location: root_path, notice: "The task 'Create a downloadable archive' is created."
+			redirect_back fallback_location: root_path, notice: "The task '#{active_job.job_name}' is created."
 		rescue => e
 			redirect_to home_path, notice: e.message
 		end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -422,9 +422,8 @@ class AnnotationsController < ApplicationController
 					filepath = File.join('tmp', "delete-#{params[:project_id]}-#{Time.now.to_s[0..18].gsub(/[ :]/, '-')}.#{ext}")
 					FileUtils.mv params[:upfile].path, filepath
 
-					active_job = DeleteAnnotationsFromUploadJob.perform_later(filepath, project, options)
-					active_job.create_job_record(project.jobs, 'Delete annotations from documents')
-					notice = "The task, 'Delete annotations from documents', is created."
+					active_job = DeleteAnnotationsFromUploadJob.perform_later(project, filepath, options)
+					notice = "The task, '#{active_job.job_name}', is created."
 				else
 					notice = "Up to 10 jobs can be registered per a project. Please clean your jobs page."
 				end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -387,12 +387,11 @@ class AnnotationsController < ApplicationController
 			FileUtils.mv file.path, filepath
 
 			if ext == '.json' && file.size < 20.kilobytes
-				StoreAnnotationsCollectionUploadJob.perform_now(filepath, project, options)
+				StoreAnnotationsCollectionUploadJob.perform_now(project, filepath, options)
 				notice = "Annotations are successfully uploaded."
 			else
-				active_job = StoreAnnotationsCollectionUploadJob.perform_later(filepath, project, options)
-				task = active_job.create_job_record(project.jobs, 'Upload annotations')
-				notice = "The task, 'Upload annotations', is created."
+				active_job = StoreAnnotationsCollectionUploadJob.perform_later(project, filepath, options)
+				notice = "The task, '#{active_job.job_name}', is created."
 			end
 
 			respond_to do |format|

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -345,9 +345,8 @@ class AnnotationsController < ApplicationController
 
 			# ObtainAnnotationsJob.perform_now(project, docids_filepath, annotator, options)
 
-			# active_job = ObtainAnnotationsJob.perform_later(project, docids_filepath, annotator, options.merge(debug: true))
-			active_job = ObtainAnnotationsJob.perform_later(project, docids_filepath, annotator, options)
-			active_job.create_job_record(project.jobs, "Obtain annotations: #{annotator.name}")
+			# ObtainAnnotationsJob.perform_later(project, docids_filepath, annotator, options.merge(debug: true))
+			ObtainAnnotationsJob.perform_later(project, docids_filepath, annotator, options)
 
 			project.update_attributes({annotator_id:annotator.id}) if annotator.persisted?
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -161,9 +161,7 @@ class CollectionsController < ApplicationController
 			# CreateAnnotationsRdfCollectionJob.perform_now(@collection, {forced:forced})
 
 			active_job = CreateAnnotationsRdfCollectionJob.perform_later(@collection, {forced:forced})
-			job_name = "Create Annotation RDF Collection - #{@collection.name}"
-			active_job.create_job_record(@collection.jobs, job_name)
-			"The task, '#{job_name}', was created."
+			"The task, '#{active_job.job_name}', was created."
 		rescue => e
 			e.message
 		end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -181,10 +181,8 @@ class CollectionsController < ApplicationController
 			# "Spans were RDFized"
 
 			active_job = CreateSpansRdfCollectionJob.perform_later(@collection)
-			job_name = "Create Spans RDF Collection- #{@collection.name}"
-			job = active_job.create_job_record(@collection.jobs, job_name)
 
-			"The task, '#{job_name}', was created."
+			"The task, '#{active_job.job_name}', was created."
 		rescue => e
 			e.message
 		end

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -457,8 +457,7 @@ class DocsController < ApplicationController
 				docids_file.puts docids
 				docids_file.close
 
-				active_job = ImportDocsJob.perform_later(docids_file.path, project)
-				active_job.create_job_record(project.jobs, 'Import docs to project')
+				ImportDocsJob.perform_later(project, docids_file.path)
 
 				m = ""
 				m += "#{num_skip} docs were skipped due to duplication." if num_skip > 0

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -595,12 +595,10 @@ class DocsController < ApplicationController
 	def update_numbers
 		begin
 			raise RuntimeError, "Not authorized" unless current_user && current_user.root? == true
-			system = Project.find_by_name('system-maintenance')
 
 			active_job = UpdateAnnotationNumbersJob.perform_later
-			active_job.create_job_record(system.jobs, "Update annotation numbers of each document")
 
-			result = {message: "The task, 'update annotation numbers of each document', created."}
+			result = {message: "The task, '#{active_job.job_name}', created."}
 			redirect_to project_path('system-maintenance')
 		rescue => e
 			flash[:notice] = e.message

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -585,8 +585,7 @@ class DocsController < ApplicationController
 			docids = projects.inject([]){|col, p| (col + p.docs.pluck(:id))}.uniq
 			system = Project.find_by_name('system-maintenance')
 
-			active_job = StoreRdfizedSpansJob.perform_later(system, docids, Pubann::Application.config.rdfizer_spans)
-			active_job.create_job_record(system.jobs, "Store RDFized spans for selected projects")
+			StoreRdfizedSpansJob.perform_later(system, docids, Pubann::Application.config.rdfizer_spans)
 		rescue => e
 			flash[:notice] = e.message
 		end

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -366,11 +366,11 @@ class DocsController < ApplicationController
 			filepath = File.join('tmp', "add-docs-to-#{params[:project_id]}-#{Time.now.to_s[0..18].gsub(/[ :]/, '-')}#{ext}")
 			FileUtils.mv params[:upfile].path, filepath
 
-			# AddDocsToProjectFromUploadJob.perform_now(sourcedb, filepath, project)
+			# AddDocsToProjectFromUploadJob.perform_now(project, sourcedb, filepath)
 
-			active_job = AddDocsToProjectFromUploadJob.perform_later(sourcedb, filepath, project)
-			job = active_job.create_job_record(project.jobs, 'Add docs to project from upload')
-			message = "The task, 'Add docs to project from upload', is created."
+			active_job = AddDocsToProjectFromUploadJob.perform_later(project, sourcedb, filepath)
+			job = Job.find_by(active_job_id: active_job.job_id)
+			message = "The task, '#{active_job.job_name}', is created."
 
 			respond_to do |format|
 				format.html {redirect_back fallback_location: root_path, notice: message }

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -419,10 +419,9 @@ class DocsController < ApplicationController
 					message = "#{docspec[:sourcedb]}:#{docspec[:sourceid]} - #{e.message}"
 				end
 			else
-				# AddDocsToProjectJob.perform_now(docspecs, project)
+				# AddDocsToProjectJob.perform_now(project, docspecs)
 
-				active_job = AddDocsToProjectJob.perform_later(docspecs, project)
-				active_job.create_job_record(project.jobs, 'Add docs to project')
+				AddDocsToProjectJob.perform_later(project, docspecs)
 				message = "The task, 'add documents to the project', is created."
 			end
 

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -290,17 +290,15 @@ class DocsController < ApplicationController
 			FileUtils.mv file.path, File.join(dirpath, filename)
 
 			if ['.json', '.txt'].include?(ext) && file.size < 100.kilobytes
-				UploadDocsJob.perform_now(dirpath, project, options)
+				UploadDocsJob.perform_now(project, dirpath, options, filename)
 				notice = "Documents are successfully uploaded."
 			else
 				raise "Up to 10 jobs can be registered per a project. Please clean your jobs page." unless project.jobs.count < 10
 
-				# UploadDocsJob.perform_now(dirpath, project, options)
+				# UploadDocsJob.perform_now(project, dirpath, options, filename)
 
-				active_job = UploadDocsJob.perform_later(dirpath, project, options)
-				task_name = "Upload documents: #{filename}"
-				active_job.create_job_record(project.jobs, task_name)
-				notice = "The task, '#{task_name}', is created."
+				active_job = UploadDocsJob.perform_later(project, dirpath, options, filename)
+				notice = "The task, '#{active_job.job_name}', is created."
 			end
 		rescue => e
 			notice = e.message

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -131,8 +131,7 @@ class EvaluationsController < ApplicationController
 				# EvaluateAnnotationsJob.perform_now(evaluation)
 
 				active_job = EvaluateAnnotationsJob.perform_later(evaluation)
-				active_job.create_job_record(evaluation.study_project.jobs, 'Evaluate annotations')
-				"The task, 'Evaluate annotations', is created. Please reload the page to see the result."
+				"The task, '#{active_job.job_name}', is created. Please reload the page to see the result."
 			end
 		rescue => e
 			e.message

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -135,9 +135,7 @@ class ProjectsController < ApplicationController
 			# UptodateDocsJob.perform_now(project)
 
 			active_job = UptodateDocsJob.perform_later(project)
-			task_name = "Uptodate docs in project - #{project.name}"
-			active_job.create_job_record(project.jobs,task_name)
-			flash[:notice] = "The task, '#{task_name}', is created."
+			flash[:notice] = "The task, '#{active_job.job_name}', is created."
 			redirect_to project_path(project.name)
 		rescue => e
 			flash[:notice] = e.message

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -201,8 +201,7 @@ class ProjectsController < ApplicationController
 			# StoreRdfizedAnnotationsJob.perform_now(project, filepath, options)
 
 			active_job = StoreRdfizedAnnotationsJob.perform_later(project, filepath, options)
-			active_job.create_job_record(project.jobs, "Store RDFized annotations - #{project.name}")
-			flash[:notice] = "The task, 'Store RDFized annotations - #{project.name}', is created."
+			flash[:notice] = "The task, '#{active_job.job_name}', is created."
 		rescue => e
 			flash[:notice] = e.message
 		end
@@ -272,8 +271,7 @@ class ProjectsController < ApplicationController
 			system = Project.find_by_name('system-maintenance')
 
 			projects.each do |project|
-				active_job = StoreRdfizedAnnotationsJob.perform_later(system, project, Pubann::Application.config.rdfizer_annotations)
-				active_job.create_job_record(system.jobs, "Store RDFized annotations - #{project.name}")
+				StoreRdfizedAnnotationsJob.perform_later(system, project, Pubann::Application.config.rdfizer_annotations)
 			end
 		rescue => e
 			flash[:notice] = e.message

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -359,10 +359,8 @@ class ProjectsController < ApplicationController
 			project = Project.editable(current_user).find_by_name(params[:project_id])
 			raise "The project does not exist, or you are not authorized to make a change to the project.\n" unless project.present?
 
-			taskname = 'Delete all annotations in project'
 			active_job = DeleteAllAnnotationsFromProjectJob.perform_later(project)
-			active_job.create_job_record(project.jobs, taskname)
-			message = "The task, '#{taskname}', is created."
+			message = "The task, '#{active_job.job_name}', is created."
 
 			respond_to do |format|
 				format.html {redirect_to project_path(project.name), notice: message}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -287,8 +287,7 @@ class ProjectsController < ApplicationController
 			docids = project.docs.pluck(:id)
 			system = Project.find_by_name('system-maintenance')
 
-			active_job = StoreRdfizedSpansJob.perform_later(system, docids, Pubann::Application.config.rdfizer_spans)
-			active_job.create_job_record(system.jobs, "Store RDFized spans - #{project.name}")
+			StoreRdfizedSpansJob.perform_later(system, docids, Pubann::Application.config.rdfizer_spans)
 		rescue => e
 			flash[:notice] = e.message
 		end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -334,8 +334,7 @@ class ProjectsController < ApplicationController
 				# DeleteAllDocsFromProjectJob.perform_now(project)
 
 				active_job = DeleteAllDocsFromProjectJob.perform_later(project)
-				active_job.create_job_record(project.jobs, 'Delete all docs')
-				"The task, 'delete all docs', is created."
+				"The task, '#{active_job.job_name}', is created."
 			else
 				"The project had no document. Nothing happened.\n"
 			end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -250,8 +250,7 @@ class ProjectsController < ApplicationController
 			# CreateSpansRdfJob.perform_now(project, nil)
 
 			active_job = CreateSpansRdfJob.perform_later(project, nil)
-			active_job.create_job_record(project.jobs, "Create Spans RDF - #{project.name}")
-			"The task, 'Create Spans RDF - #{project.name}', is created."
+			"The task, '#{active_job.job_name}', is created."
 		rescue => e
 			e.message
 		end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -234,8 +234,7 @@ class ProjectsController < ApplicationController
 			# CreateAnnotationsRdfJob.perform_now(project)
 
 			active_job = CreateAnnotationsRdfJob.perform_later(project)
-			active_job.create_job_record(project.jobs, "Create Annotation RDF - #{project.name}")
-			"The task, 'Create Annotation RDF - #{project.name}', is created."
+			"The task, '#{active_job.job_name}', is created."
 		rescue => e
 			e.message
 		end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -381,10 +381,7 @@ class ProjectsController < ApplicationController
 		project = Project.editable(current_user).find_by_name(params[:id])
 		raise "There is no such project." unless project.present?
 
-		sproject = Project.find_by_name('system-maintenance')
-
-		active_job = DestroyProjectJob.perform_later(project)
-		active_job.create_job_record(sproject.jobs, 'Destroy project')
+		DestroyProjectJob.perform_later(project)
 
 		respond_to do |format|
 			format.html {redirect_to projects_path, status: :see_other, notice: "The project, #{@project.name}, will be deleted soon."}

--- a/app/jobs/add_docs_to_project_from_upload_job.rb
+++ b/app/jobs/add_docs_to_project_from_upload_job.rb
@@ -1,7 +1,7 @@
 class AddDocsToProjectFromUploadJob < ApplicationJob
 	queue_as :general
 
-	def perform(sourcedb, filepath, project)
+	def perform(project, sourcedb, filepath)
 		count = %x{wc -l #{filepath}}.split.first.to_i
 
 		if @job
@@ -43,6 +43,10 @@ class AddDocsToProjectFromUploadJob < ApplicationJob
 		end
 
 		File.unlink(filepath)
+	end
+
+	def job_name
+		'Add docs to project from upload'
 	end
 
 	private

--- a/app/jobs/add_docs_to_project_job.rb
+++ b/app/jobs/add_docs_to_project_job.rb
@@ -1,7 +1,7 @@
 class AddDocsToProjectJob < ApplicationJob
 	queue_as :general
 
-	def perform(docspecs, project)
+	def perform(project, docspecs)
 		if @job
 			prepare_progress_record(docspecs.length)
 		end
@@ -66,5 +66,9 @@ class AddDocsToProjectJob < ApplicationJob
 			ActionController::Base.new.expire_fragment("count_docs_#{project.name}")
 			sourcedbs.uniq.each{|sdb| ActionController::Base.new.expire_fragment("count_#{sdb}_#{project.name}")}
 		end
+	end
+
+	def job_name
+		'Add docs to project'
 	end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -10,6 +10,8 @@ class ApplicationJob < ActiveJob::Base
   end
 
   before_enqueue do
+    # When creating a new job,
+    # be sure to pass the organization to which the Job record belongs to the first argument of the perform method.
     organization = self.arguments.first
     create_job_record(organization.jobs, self.job_name(organization.name))
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -12,8 +12,7 @@ class ApplicationJob < ActiveJob::Base
   before_enqueue do
     # When creating a new job,
     # be sure to pass the organization to which the Job record belongs to the first argument of the perform method.
-    organization = self.arguments.first
-    create_job_record(organization.jobs, self.job_name(organization.name))
+    create_job_record(organization_jobs, self.job_name)
   end
 
   before_perform do |active_job|
@@ -29,6 +28,14 @@ class ApplicationJob < ActiveJob::Base
   end
 
   private
+
+  def organization_jobs
+    self.arguments.first.jobs
+  end
+
+  def resource_name
+    self.arguments.first.name
+  end
 
   def create_job_record(organization_jobs, job_name)
     organization_jobs.create({ name: job_name, active_job_id: self.job_id, queue_name: self.queue_name })

--- a/app/jobs/create_annotations_rdf_collection_job.rb
+++ b/app/jobs/create_annotations_rdf_collection_job.rb
@@ -14,7 +14,7 @@ class CreateAnnotationsRdfCollectionJob < ApplicationJob
 			if forced?(options) || project.rdf_needs_to_be_updated?
 				if @job
 					active_job = CreateAnnotationsRdfJob.perform_later(project)
-					monitor_job = active_job.create_job_record(collection.jobs, "Create Annotation RDF - #{project.name}")
+					monitor_job = Job.find_by(active_job_id: active_job.job_id)
 					until monitor_job.finished_live?
 						sleep(1)
 						ActiveRecord::Base.connection.clear_query_cache

--- a/app/jobs/create_annotations_rdf_collection_job.rb
+++ b/app/jobs/create_annotations_rdf_collection_job.rb
@@ -42,7 +42,7 @@ class CreateAnnotationsRdfCollectionJob < ApplicationJob
 		# creation of spans RDF
 		if @job
 			active_job = CreateSpansRdfCollectionJob.perform_later(collection)
-			monitor_job = active_job.create_job_record(collection.jobs, "Create Spans RDF Collection- #{collection.name}")
+			monitor_job = Job.find_by(active_job_id: active_job.job_id)
 			until monitor_job.finished_live?
 				sleep(1)
 				ActiveRecord::Base.connection.clear_query_cache

--- a/app/jobs/create_annotations_rdf_collection_job.rb
+++ b/app/jobs/create_annotations_rdf_collection_job.rb
@@ -58,4 +58,8 @@ class CreateAnnotationsRdfCollectionJob < ApplicationJob
 	def forced?(options)
 		options && options.has_key?(:forced) ? options[:forced] == true : false
 	end
+
+	def job_name
+		"Create Annotation RDF Collection - #{resource_name}"
+	end
 end

--- a/app/jobs/create_annotations_rdf_job.rb
+++ b/app/jobs/create_annotations_rdf_job.rb
@@ -14,4 +14,8 @@ class CreateAnnotationsRdfJob < ApplicationJob
 			end
 		end
 	end
+
+	def job_name
+		"Create Annotation RDF - #{resource_name}"
+	end
 end

--- a/app/jobs/create_annotations_tgz_job.rb
+++ b/app/jobs/create_annotations_tgz_job.rb
@@ -98,4 +98,8 @@ class CreateAnnotationsTgzJob < ApplicationJob
 		FileUtils.mkdir_p(project.downloads_system_path) unless Dir.exist?(project.downloads_system_path)
 		FileUtils.mv tmp_file_path, project.annotations_tgz_system_path
 	end
+
+	def job_name
+		'Create a downloadable archive'
+	end
 end

--- a/app/jobs/create_spans_rdf_collection_job.rb
+++ b/app/jobs/create_spans_rdf_collection_job.rb
@@ -35,4 +35,8 @@ class CreateSpansRdfCollectionJob < ApplicationJob
 			end
 		end
 	end
+
+	def job_name
+		"Create Spans RDF Collection- #{resource_name}"
+	end
 end

--- a/app/jobs/create_spans_rdf_job.rb
+++ b/app/jobs/create_spans_rdf_job.rb
@@ -14,4 +14,8 @@ class CreateSpansRdfJob < ApplicationJob
 			end
 		end
 	end
+
+	def job_name
+		"Create Spans RDF - #{resource_name}"
+	end
 end

--- a/app/jobs/delete_all_annotations_from_project_job.rb
+++ b/app/jobs/delete_all_annotations_from_project_job.rb
@@ -12,4 +12,8 @@ class DeleteAllAnnotationsFromProjectJob < ApplicationJob
 		@job.update_attribute(:num_dones, 1)
 		project.update_attribute(:annotations_count, 0)
 	end
+
+	def job_name
+		'Delete all annotations in project'
+	end
 end

--- a/app/jobs/delete_all_docs_from_project_job.rb
+++ b/app/jobs/delete_all_docs_from_project_job.rb
@@ -8,8 +8,7 @@ class DeleteAllDocsFromProjectJob < ApplicationJob
 
 		project.delete_docs
 
-		active_job = UpdateElasticsearchIndexJob.perform_later(project)
-		active_job.create_job_record(project.jobs, 'Update text search index')
+		UpdateElasticsearchIndexJob.perform_later(project)
 
 		@job.update_attribute(:num_dones, 1) if @job
 		ActionController::Base.new.expire_fragment("sourcedb_counts_#{project.name}")

--- a/app/jobs/delete_all_docs_from_project_job.rb
+++ b/app/jobs/delete_all_docs_from_project_job.rb
@@ -15,4 +15,8 @@ class DeleteAllDocsFromProjectJob < ApplicationJob
 		ActionController::Base.new.expire_fragment("sourcedb_counts_#{project.name}")
 		ActionController::Base.new.expire_fragment("count_docs_#{project.name}")
 	end
+
+	def job_name
+		'Delete all docs'
+	end
 end

--- a/app/jobs/delete_annotations_from_upload_job.rb
+++ b/app/jobs/delete_annotations_from_upload_job.rb
@@ -1,7 +1,7 @@
 class DeleteAnnotationsFromUploadJob < ApplicationJob
 	queue_as :low_priority
 
-	def perform(filepath, project, options)
+	def perform(project, filepath, options)
 		dirpath = nil
 		jsonfiles = if filepath.end_with?('.json')
 			Dir.glob(filepath)
@@ -43,5 +43,9 @@ class DeleteAnnotationsFromUploadJob < ApplicationJob
 
 		File.unlink(filepath)
 		FileUtils.rm_rf(dirpath) unless dirpath.nil?
+	end
+
+	def job_name
+		'Delete annotations from documents'
 	end
 end

--- a/app/jobs/destroy_project_job.rb
+++ b/app/jobs/destroy_project_job.rb
@@ -15,4 +15,14 @@ class DestroyProjectJob < ApplicationJob
 		project.destroy
 		@job.update_attribute(:num_dones, 3)
 	end
+
+	def job_name
+		'Destroy project'
+	end
+
+	private
+
+	def organization_jobs
+		Project.find_by_name('system-maintenance').jobs
+	end
 end

--- a/app/jobs/evaluate_annotations_job.rb
+++ b/app/jobs/evaluate_annotations_job.rb
@@ -49,4 +49,14 @@ class EvaluateAnnotationsJob < ApplicationJob
 
 		evaluation.update_attribute(:result, JSON.generate(result))
 	end
+
+	def job_name
+		'Evaluate annotations'
+	end
+
+	private
+
+	def organization_jobs
+		self.arguments.first.study_project.jobs
+	end
 end

--- a/app/jobs/import_annotations_job.rb
+++ b/app/jobs/import_annotations_job.rb
@@ -1,7 +1,7 @@
 class ImportAnnotationsJob < ApplicationJob
 	queue_as :general
 
-	def perform(source_project, project)
+	def perform(project, source_project)
 		docs = project.docs & source_project.docs
 
 		prepare_progress_record(docs.length)
@@ -17,5 +17,15 @@ class ImportAnnotationsJob < ApplicationJob
 			@job.update_attribute(:num_dones, i + 1)
 			check_suspend_flag
 		end
+	end
+
+	def job_name
+		"Import annotations from #{resource_name}"
+	end
+
+	private
+
+	def resource_name
+		self.arguments[1].name
 	end
 end

--- a/app/jobs/import_docs_job.rb
+++ b/app/jobs/import_docs_job.rb
@@ -1,7 +1,7 @@
 class ImportDocsJob < ApplicationJob
 	queue_as :general
 
-	def perform(filepath, project)
+	def perform(project, filepath)
 		count = %x{wc -l #{filepath}}.split.first.to_i
 
 		prepare_progress_record(count)
@@ -20,5 +20,9 @@ class ImportDocsJob < ApplicationJob
 			ActionController::Base.new.expire_fragment("count_docs_#{project.name}")
 			sourcedb_h.each_key{|sdb| ActionController::Base.new.expire_fragment("count_#{sdb}_#{project.name}")}
 		end
+	end
+
+	def job_name
+		'Import docs to project'
 	end
 end

--- a/app/jobs/obtain_annotations_job.rb
+++ b/app/jobs/obtain_annotations_job.rb
@@ -135,6 +135,10 @@ class ObtainAnnotationsJob < ApplicationJob
 		File.unlink(filepath)
 	end
 
+	def job_name
+		"Obtain annotations: #{resource_name}"
+	end
+
 private
 
 	def make_request_batch(project, docs, annotator, options)
@@ -288,5 +292,9 @@ private
 		exception.message
 	rescue => e
 		"exception message inaccessible:\n#{exception}:\n#{exception.backtrace.join("\n")}"
+	end
+
+	def resource_name
+		self.arguments[2].name
 	end
 end

--- a/app/jobs/obtain_doc_annotations_job.rb
+++ b/app/jobs/obtain_doc_annotations_job.rb
@@ -1,7 +1,7 @@
 class ObtainDocAnnotationsJob < ApplicationJob
 	queue_as :general
 
-	def perform(annotator, project, docid, options)
+	def perform(project, docid, annotator, options)
 		doc = Doc.find(docid)
 		doc.set_ascii_body if options[:encoding].present? && options[:encoding] == 'ascii'
 		max_text_size = annotator.async_protocol ? Annotator::MaxTextAsync : Annotator::MaxTextSync
@@ -58,6 +58,10 @@ class ObtainDocAnnotationsJob < ApplicationJob
 		end
 	end
 
+	def job_name
+		"Obtain annotations for a document: #{resource_name}"
+	end
+
 	private
 
 	def retrieve_and_store(url, annotator, project, options)
@@ -111,5 +115,9 @@ class ObtainDocAnnotationsJob < ApplicationJob
 		else
 			raise ArgumentError, e.message
 		end
+	end
+
+	def resource_name
+		self.arguments[2].name
 	end
 end

--- a/app/jobs/store_annotations_collection_upload_job.rb
+++ b/app/jobs/store_annotations_collection_upload_job.rb
@@ -3,7 +3,7 @@ class StoreAnnotationsCollectionUploadJob < ApplicationJob
 
 	MAX_SIZE_TRANSACTION = 5000
 
-	def perform(filepath, project, options)
+	def perform(project, filepath, options)
 		# read the filenames of json files into the array filenames
 		filenames, dirpath = read_filenames(filepath)
 
@@ -75,6 +75,10 @@ class StoreAnnotationsCollectionUploadJob < ApplicationJob
 		File.unlink(filepath)
 		FileUtils.rm_rf(dirpath) unless dirpath.nil?
 		true
+	end
+
+	def job_name
+		'Upload annotations'
 	end
 
 	private

--- a/app/jobs/store_rdfized_annotations_job.rb
+++ b/app/jobs/store_rdfized_annotations_job.rb
@@ -139,6 +139,10 @@ class StoreRdfizedAnnotationsJob < ApplicationJob
 		File.unlink(filepath)
 	end
 
+	def job_name
+		"Store RDFized annotations - #{resource_name}"
+	end
+
 	private
 
 	def update_project_metadata(sd, database, project)

--- a/app/jobs/store_rdfized_spans_job.rb
+++ b/app/jobs/store_rdfized_spans_job.rb
@@ -25,4 +25,8 @@ class StoreRdfizedSpansJob < ApplicationJob
 			end
 		end
 	end
+
+	def job_name
+		"Store RDFized spans for selected projects"
+	end
 end

--- a/app/jobs/update_annotation_numbers_job.rb
+++ b/app/jobs/update_annotation_numbers_job.rb
@@ -26,4 +26,14 @@ class UpdateAnnotationNumbersJob < ApplicationJob
 			end
 		end
 	end
+
+	def job_name
+		"Update annotation numbers of each document"
+	end
+
+	private
+
+	def organization_jobs
+		Project.find_by_name('system-maintenance').jobs
+	end
 end

--- a/app/jobs/update_elasticsearch_index_job.rb
+++ b/app/jobs/update_elasticsearch_index_job.rb
@@ -8,4 +8,8 @@ class UpdateElasticsearchIndexJob < ApplicationJob
 		project.update_es_index
 		@job.update_attribute(:num_dones, 1) if @job
 	end
+
+	def job_name
+		'Update text search index'
+	end
 end

--- a/app/jobs/upload_docs_job.rb
+++ b/app/jobs/upload_docs_job.rb
@@ -1,7 +1,7 @@
 class UploadDocsJob < ApplicationJob
 	queue_as :low_priority
 
-	def perform(dirpath, project, options)
+	def perform(project, dirpath, options, filename)
 		upfilepath = Dir.glob(File.join(dirpath, '**', '*')).first
 
 		infiles = if upfilepath.end_with?('.json') || upfilepath.end_with?('.txt')
@@ -106,5 +106,15 @@ class UploadDocsJob < ApplicationJob
 
 		FileUtils.rm_rf(dirpath) unless dirpath.nil?
 		true
+	end
+
+	def job_name
+		"Upload documents: #{resource_name}"
+	end
+
+	private
+
+	def resource_name
+		self.arguments[3]
 	end
 end

--- a/app/jobs/uptodate_docs_job.rb
+++ b/app/jobs/uptodate_docs_job.rb
@@ -59,4 +59,8 @@ class UptodateDocsJob < ApplicationJob
 			end
 		end
 	end
+
+	def job_name
+		"Uptodate docs in project - #{resource_name}"
+	end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -87,7 +87,7 @@ class Collection < ActiveRecord::Base
 			# CreateSpansRdfJob.perform_now(pproject)
 
 			active_job = CreateSpansRdfJob.perform_later(pproject, self)
-			job = active_job.create_job_record(pproject.jobs, "Create Spans RDF - #{pproject.name}")
+			job = Job.find_by(active_job_id: active_job.job_id)
 			sleep(1) until job.finished_live?
 
 			FileUtils.ln_sf(pproject.spans_trig_filepath, annotations_rdf_dirpath)


### PR DESCRIPTION
## Purpose
Changed the create_job_record method to be executed in the before_enqueue callback so that the set_job method in before_perform is executed after the Job record is created.

## Change List
- Migrate create_job_record in before_enqueue
- Change the order of arguments in some jobs
  - Because the organization must be passed as the first argument for the convenience of the before_enqueue_process method.
- Define job_name method in Job class