### PR TITLE
AnnotationReceptionControllerを作成

### DIFF
--- a/app/controllers/annotation_reception_controller.rb
+++ b/app/controllers/annotation_reception_controller.rb
@@ -1,4 +1,5 @@
 class AnnotationReceptionController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:update]
 
   def update; end
 

--- a/app/controllers/annotation_reception_controller.rb
+++ b/app/controllers/annotation_reception_controller.rb
@@ -1,0 +1,5 @@
+class AnnotationReceptionController < ApplicationController
+
+  def update; end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,6 +302,7 @@ Pubann::Application.routes.draw do
 	get '/search' => 'graphs#show', :as => :sparql
 	get '/projects/:project_name/search' => 'graphs#show', :as => :sparql_project
 	get '/collections/:collection_name/search' => 'graphs#show', :as => :sparql_collection
+	put '/annotation_reception/:uuid' => 'annotation_reception#update'
 
   # Evidence Block Search API
   resources :term_search, only: [:index]


### PR DESCRIPTION
## 概要
アノテーション結果を受け取り処理をするコントローラーを作成しました。

## 実装内容
- AnnotationReceptionControllerの作成
- ルーティングを追記
- CSRF警告が出ていたので無効化

## 動作確認
ターミナルで `curl -X PUT http://localhost:3000/annotation_reception/sample-uuid`を実行
![image](https://github.com/user-attachments/assets/bcb3d993-dc5f-43c1-9df9-d6cce4c2c57e)
