### PR TITLE
ObtainAnnotationsWithCallbackJob実行時にもJobテーブルが更新されるよう改善

### DIFF
--- a/app/controllers/annotation_reception_controller.rb
+++ b/app/controllers/annotation_reception_controller.rb
@@ -6,7 +6,6 @@ class AnnotationReceptionController < ApplicationController
     annotations_collection = get_result_from_json_body
 
     annotation_reception.process_annotation!(annotations_collection)
-    annotation_reception.destroy
 
     head :no_content
   rescue ActiveRecord::RecordNotFound => e

--- a/app/controllers/annotation_reception_controller.rb
+++ b/app/controllers/annotation_reception_controller.rb
@@ -6,6 +6,7 @@ class AnnotationReceptionController < ApplicationController
     annotations_collection = get_result_from_json_body
 
     annotation_reception.process_annotation!(annotations_collection)
+    annotation_reception.destroy
 
     head :no_content
   rescue ActiveRecord::RecordNotFound => e

--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -74,13 +74,6 @@ private
                        sourceid:doc.sourceid,
                        body: "The document was too big to be processed at once (#{number_with_delimiter(doc.body.length)} > #{number_with_delimiter(annotator.find_or_define_max_text_size)}). For proceding, it was divided into #{request_count} slices."
     end
-
-    uuid = SecureRandom.uuid
-    AnnotationReception.create!(annotator_id: annotator.id, project_id: project.id, job_id: @job.id, uuid:, options:)
-    method, url, params, payload = annotator.prepare_request(hdocs)
-    payload[:callback_url] = "#{Rails.application.config.host_url}/annotation_reception/#{uuid}"
-
-    annotator.make_request(method, url, params, payload)
   end
 
   def add_sliced_doc_exception_message_to_job(request_info, doc)

--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -74,6 +74,13 @@ private
                        sourceid:doc.sourceid,
                        body: "The document was too big to be processed at once (#{number_with_delimiter(doc.body.length)} > #{number_with_delimiter(annotator.find_or_define_max_text_size)}). For proceding, it was divided into #{request_count} slices."
     end
+
+    uuid = SecureRandom.uuid
+    AnnotationReception.create!(annotator_id: annotator.id, project_id: project.id, job_id: @job.id, uuid:, options:)
+    method, url, params, payload = annotator.prepare_request(hdocs)
+    payload[:callback_url] = "#{Rails.application.config.host_url}/annotation_reception/#{uuid}"
+
+    annotator.make_request(method, url, params, payload)
   end
 
   def add_sliced_doc_exception_message_to_job(request_info, doc)

--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -10,7 +10,7 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
     prepare_progress_record(doc_count)
 
     # for asynchronous protocol
-    doc_collection = DocCollection.new(project, annotator, options)
+    doc_collection = DocCollection.new(project, annotator, @job.id, options)
 
     File.foreach(filepath) do |line|
       docid = line.chomp.strip

--- a/app/models/annotation_reception.rb
+++ b/app/models/annotation_reception.rb
@@ -14,5 +14,8 @@ class AnnotationReception < ApplicationRecord
     end
 
     StoreAnnotationsCollection.new(project, annotations_collection, options).call.join
+
+    job.increment!(:num_dones, annotations_collection.length)
+    job.finish!
   end
 end

--- a/app/models/annotation_reception.rb
+++ b/app/models/annotation_reception.rb
@@ -1,6 +1,7 @@
 class AnnotationReception < ApplicationRecord
   belongs_to :annotator
   belongs_to :project
+  belongs_to :job
 
   validates :annotator_id, presence: true
   validates :project_id, presence: true

--- a/app/models/doc_collection.rb
+++ b/app/models/doc_collection.rb
@@ -2,10 +2,11 @@ class DocCollection
   attr_accessor :docs
   attr_reader :size
 
-  def initialize(project, annotator, options)
+  def initialize(project, annotator, job_id, options)
     @project = project
     @annotator = annotator
     @max_text_size = annotator.find_or_define_max_text_size
+    @job_id = job_id
     @options = options
     @docs = []
     @size = 0
@@ -72,7 +73,7 @@ class DocCollection
   end
 
   def make_request(hdocs, options)
-    annotation_reception = AnnotationReception.create!(annotator_id: @annotator.id, project_id: @project.id, options:)
+    annotation_reception = AnnotationReception.create!(annotator_id: @annotator.id, project_id: @project.id, job_id: @job_id, options:)
     method, url, params, payload = @annotator.prepare_request(hdocs)
     payload[:callback_url] = "#{Rails.application.config.host_url}/annotation_reception/#{annotation_reception.uuid}"
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,7 +1,7 @@
 class Job < ActiveRecord::Base
   belongs_to :organization, polymorphic: true
   has_many :messages # "dependent: :destroy" is omitted. They are explicitly deleted in the destroy method
-  has_many :annotation_receptions, dependent: :destroy
+  has_many :annotation_receptions # "dependent: :destroy" is omitted. They are explicitly destroyed in the destroy method
 
   scope :waiting, -> { where('begun_at IS NULL') }
   scope :running, -> { where('begun_at IS NOT NULL AND ended_at IS NULL') }
@@ -86,6 +86,7 @@ class Job < ActiveRecord::Base
 
   def destroy
     ActiveRecord::Base.connection.exec_query("DELETE FROM messages WHERE job_id = #{id}")
+    annotation_receptions.destroy_all
     self.delete
   end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,6 +1,7 @@
 class Job < ActiveRecord::Base
   belongs_to :organization, polymorphic: true
   has_many :messages # "dependent: :destroy" is omitted. They are explicitly deleted in the destroy method
+  has_many :annotation_receptions, dependent: :destroy
 
   scope :waiting, -> { where('begun_at IS NULL') }
   scope :running, -> { where('begun_at IS NOT NULL AND ended_at IS NULL') }

--- a/db/migrate/20240731020157_add_job_reference_column_to_annotation_reception.rb
+++ b/db/migrate/20240731020157_add_job_reference_column_to_annotation_reception.rb
@@ -1,0 +1,5 @@
+class AddJobReferenceColumnToAnnotationReception < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :annotation_receptions, :job, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_25_003116) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_31_020157) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,7 +21,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_003116) do
     t.bigint "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "job_id"
     t.index ["annotator_id"], name: "index_annotation_receptions_on_annotator_id"
+    t.index ["job_id"], name: "index_annotation_receptions_on_job_id"
     t.index ["project_id"], name: "index_annotation_receptions_on_project_id"
   end
 
@@ -421,6 +423,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_003116) do
   end
 
   add_foreign_key "annotation_receptions", "annotators"
+  add_foreign_key "annotation_receptions", "jobs"
   add_foreign_key "annotation_receptions", "projects"
   add_foreign_key "attrivutes", "docs"
   add_foreign_key "paragraph_attrivutes", "attrivutes"


### PR DESCRIPTION
## 概要
ObtainAnnotationsWithCallbackJob実行時にもJobテーブルが更新されるよう改善しました。

## 実装内容
- 作成したコールバックAPIでJobの情報を取得できるようにAnnotationReceptionモデルにjob_idカラムを追加
- コールバックAPI内で処理が終わるとJobの情報を更新
- 処理が終わるとAnnotationReceptionレコードを削除する形から、Jobを削除した時に同時にAnnotationReceptionが削除される形に変更

## 動作確認
### Job一覧ページ
Progressの分子が結果によって変わっていることが確認できます。
|<img width="1081" alt="image" src="https://github.com/user-attachments/assets/0ebb8fde-78a0-406e-bc9b-84da164263f4">|
|:-|

### Job詳細ページ
`Ended_at`, `Elapsed`, `Pace`が更新されています。
|<img width="626" alt="image" src="https://github.com/user-attachments/assets/6577337c-7d84-43a3-8431-154e1f1892dc">|
|:-|