### PR TITLE
不要な例外処理を削除

### DIFF
--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -23,8 +23,6 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
           add_sliced_doc_exception_message_to_job(request_info, doc) if error_occured?(request_info)
           update_job_items(annotator, doc_collection.docs.first, request_info[:request_count])
 
-        rescue Exceptions::JobSuspendError
-          raise
         rescue StandardError, RestClient::RequestFailed => e
           less_docs_message = 'Could not obtain annotations:'
           many_docs_message = 'Could not obtain annotations for'
@@ -36,8 +34,6 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
 
       doc_collection << doc
 
-    rescue Exceptions::JobSuspendError
-      raise
     rescue RuntimeError => e
       less_docs_message = 'Runtime error:'
       many_docs_message = 'Runtime error while processing'

--- a/app/models/doc_collection.rb
+++ b/app/models/doc_collection.rb
@@ -59,8 +59,6 @@ class DocCollection
         hdoc = [{text:doc.get_text(@options[:span]), sourcedb:doc.sourcedb, sourceid:doc.sourceid}]
         make_request(hdoc, @options.merge(span:slice))
         errors << ""
-      rescue Exceptions::JobSuspendError
-        raise
       rescue RestClient::InternalServerError => e
         errors << e
         break


### PR DESCRIPTION
## 概要
ObtainAnnotationsWithCallbackJobにおいて不要になったJobSuspendErrorの例外処理を削除しました。