### PR TITLE
ドキュメント分割の修正, 実装

### DIFF
--- a/app/models/annotation_reception.rb
+++ b/app/models/annotation_reception.rb
@@ -13,7 +13,17 @@ class AnnotationReception < ApplicationRecord
       annotator.annotations_transform!(annotations)
     end
 
-    StoreAnnotationsCollection.new(project, annotations_collection, options).call.join
+    symbolized_options = options.deep_symbolize_keys
+
+    if symbolized_options[:span].present?
+      messages = project.save_annotations!(annotations_collection.first, Doc.find(symbolized_options[:docid]), symbolized_options)
+      messages.each do |m|
+        m = {body: m} if m.class == String
+        job.add_message m
+      end
+    else
+      StoreAnnotationsCollection.new(project, annotations_collection, symbolized_options).call.join
+    end
 
     job.increment!(:num_dones, annotations_collection.length)
     job.finish!

--- a/app/models/annotation_reception.rb
+++ b/app/models/annotation_reception.rb
@@ -22,7 +22,7 @@ class AnnotationReception < ApplicationRecord
         job.add_message m
       end
     else
-      StoreAnnotationsCollection.new(project, annotations_collection, symbolized_options).call.join
+      StoreAnnotationsCollection.new(project, annotations_collection, symbolized_options, job).call.join
     end
 
     job.increment!(:num_dones, annotations_collection.length)

--- a/app/models/doc_collection.rb
+++ b/app/models/doc_collection.rb
@@ -56,7 +56,7 @@ class DocCollection
 
     slices.each do |slice|
       begin
-        hdoc = [{text:doc.get_text(@options[:span]), sourcedb:doc.sourcedb, sourceid:doc.sourceid}]
+        hdoc = [{text:doc.get_text(slice), sourcedb:doc.sourcedb, sourceid:doc.sourceid}]
         make_request(hdoc, @options.merge(span:slice))
         errors << ""
       rescue RestClient::InternalServerError => e

--- a/app/models/doc_collection.rb
+++ b/app/models/doc_collection.rb
@@ -57,7 +57,7 @@ class DocCollection
     slices.each do |slice|
       begin
         hdoc = [{text:doc.get_text(slice), sourcedb:doc.sourcedb, sourceid:doc.sourceid}]
-        make_request(hdoc, @options.merge(span:slice))
+        make_request(hdoc, @options.merge(span:slice, docid: doc.id))
         errors << ""
       rescue RestClient::InternalServerError => e
         errors << e


### PR DESCRIPTION
Closes: #118

## 概要
[issue](https://github.com/pubannotation/pubannotation/issues/118)の内容を調査した結果、指摘通りドキュメント分割が正しく出来ていませんでした。
よってドキュメント分割の修正を行い、加えて不足していたコールバックAPI側での分割処理の追加を行いました。

## 実装内容
- リクエスト送信時にドキュメント分割が正しく行われるように修正
- コールバックAPIでドキュメントが分割されている場合の処理を追加

## 動作確認
### ドキュメント分割の修正
こちらのドキュメントに対し、2に分割されるように文字サイズ上限を設定します。
|<img width="1030" alt="image" src="https://github.com/user-attachments/assets/671c6e30-ecfa-4e83-8e8d-ce6824b500e1">|
|:-|

リクエストに添付するドキュメントを確認します。
```
slices.each do |slice|
  begin
    hdoc = [{text:doc.get_text(slice), sourcedb:doc.sourcedb, sourceid:doc.sourceid}]
    pp hdoc
    make_request(hdoc, @options.merge(span:slice, docid: doc.id))
```
#### 結果
分割されています。
![image](https://github.com/user-attachments/assets/63079e9e-c668-471e-be0b-159b3710ab54)

### コールバックAPIでの処理
`if options[:span]`ブロックに入り、処理をしていることを確認しました。
![image](https://github.com/user-attachments/assets/1e022865-09b8-46d3-8344-8a5d0bb6acb2)
![image](https://github.com/user-attachments/assets/6df76322-9ec1-44ca-8c92-947034877a7d)
