### PR TITLE
request_infoをHashからValue Objectに変更

### DIFF
--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -21,7 +21,7 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
         begin
           request_info = doc_collection.request_annotate
           add_sliced_doc_exception_message_to_job(request_info, doc) if error_occured?(request_info)
-          update_job_items(annotator, doc_collection.docs.first, request_info[:request_count])
+          update_job_items(annotator, doc_collection.docs.first, request_info.count)
 
         rescue StandardError, RestClient::RequestFailed => e
           less_docs_message = 'Could not obtain annotations:'
@@ -44,7 +44,7 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
       begin
         request_info = doc_collection.request_annotate
         add_sliced_doc_exception_message_to_job(request_info, doc_collection.docs.first) if error_occured?(request_info)
-        update_job_items(annotator, doc_collection.docs.first, request_info[:request_count])
+        update_job_items(annotator, doc_collection.docs.first, request_info.count)
 
       rescue StandardError, RestClient::RequestFailed => e
         less_docs_message = 'Could not obtain annotations:'
@@ -73,8 +73,8 @@ private
   end
 
   def add_sliced_doc_exception_message_to_job(request_info, doc)
-    slices = request_info[:slices]
-    errors = request_info[:errors]
+    slices = request_info.slices
+    errors = request_info.errors
 
     slices.each_with_index do |slice, i|
       next if errors[i].blank?
@@ -105,7 +105,7 @@ private
   end
 
   def error_occured?(request_info)
-    request_info.key?(:errors) && request_info[:errors].reject(&:blank?).any?
+    request_info.errors.reject(&:blank?).any?
   end
 
   def resource_name

--- a/app/models/doc_collection.rb
+++ b/app/models/doc_collection.rb
@@ -2,6 +2,8 @@ class DocCollection
   attr_accessor :docs
   attr_reader :size
 
+  RequestInfo = Data.define(:count, :slices, :errors)
+
   def initialize(project, annotator, job_id, options)
     @project = project
     @annotator = annotator
@@ -13,17 +15,13 @@ class DocCollection
   end
 
   def request_annotate
-    request_info = {}
-
     if document_too_large?
-      request_info = slice(@docs.first)
+      slice(@docs.first)
     else
       hdocs = docs.map{_1.hdoc}
       make_request(hdocs, @options)
-      request_info[:request_count] = 1
+      RequestInfo.new(1, [], [])
     end
-
-    request_info
   end
 
   def filled_with?(doc)
@@ -67,7 +65,7 @@ class DocCollection
       end
     end
 
-    {request_count:, slices:, errors:}
+    RequestInfo.new(request_count, slices, errors)
   end
 
   def make_request(hdocs, options)


### PR DESCRIPTION
Closes: #119

## 概要
情報の整合性, 可読性向上のためrequest_info変数をHashからValue Objectに変更しました。
[該当issue](https://github.com/pubannotation/pubannotation/issues/119)

## 実装内容
- DocCollectionクラスが返すリクエスト詳細をvalue objectに変更
  - ObtainAnnotationsWithCallbackJob側も変更に合わせて調整

## 動作確認
修正前と同じく動作します。
### sliceされない場合
![image](https://github.com/user-attachments/assets/b6416dda-3ed9-4b37-b04d-f41207b7d358)

### sliceされる場合
![image](https://github.com/user-attachments/assets/747924c6-841a-433e-98fe-540fde3ef836)
![image](https://github.com/user-attachments/assets/f1da4650-da20-4834-8716-3429d42ec202)
