### PR TITLE
ObtainAnnotationsWithCallbackJob周りのリファクタリング

### DIFF
--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -11,7 +11,7 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
       doc_packer << line.chomp.strip
     end
 
-    prepare_progress_record(doc_packer.hdocs_count)
+    prepare_progress_record(doc_packer.request_count)
 
     doc_packer.each do |hdocs, doc, error, slice_count|
       # Handle document slice error

--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -28,7 +28,7 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
           begin
             make_request(annotator, project, [hdoc], options)
           rescue StandardError, RestClient::RequestFailed => e
-            add_exception_message_to_job(hdoc, e)
+            add_exception_message_to_job([hdoc], e)
             break if e.class == RestClient::InternalServerError
           end
         end
@@ -79,27 +79,21 @@ private
                      body: "The document was too big to be processed at once (#{number_with_delimiter(doc.body.length)} > #{number_with_delimiter(annotator.find_or_define_max_text_size)}). For proceding, it was divided into #{request_count} slices."
   end
 
-  def add_exception_message_to_job(hdoc, e)
-    if hdoc.is_a?(Array)
-      sourcedb = hdoc.map { _1[:sourcedb] }.uniq.join(', ')
-      sourceid = hdoc.map { _1[:sourceid] }.uniq.join(', ')
-    else
-      sourcedb = hdoc[:sourcedb]
-      sourceid = hdoc[:sourceid]
-    end
-
+  def add_exception_message_to_job(hdocs, e)
     e_explanation =
-      if hdoc.is_a?(Hash) && hdoc[:span].present?
+      if hdocs.length == 1 && hdocs.first[:span].present?
         if e.class == RuntimeError
-          "Could not obtain for the slice (#{hdoc[:span][:begin]}, #{hdoc[:span][:end]}):"
+          "Could not obtain for the slice (#{hdocs.first[:span][:begin]}, #{hdocs.first[:span][:end]}):"
         else
-          "Error while processing the slice (#{hdoc[:span][:begin]}, #{hdoc[:span][:end]}):"
+          "Error while processing the slice (#{hdocs.first[:span][:begin]}, #{hdocs.first[:span][:end]}):"
         end
       else
         "Could not obtain annotations:"
       end
 
-    @job.add_message sourcedb:, sourceid:, body: "#{e_explanation} #{e.message}"
+    @job.add_message sourcedb: hdocs.map { _1[:sourcedb] }.uniq.join(', '),
+                     sourceid: hdocs.map { _1[:sourceid] }.uniq.join(', '),
+                     body: "#{e_explanation} #{e.message}"
   end
 
   def resource_name

--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -20,7 +20,7 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
         next
       end
 
-      add_slice_message_to_job(annotator, doc, hdocs.length)
+      add_slice_message_to_job(annotator, doc, hdocs.length) if hdocs.any? { _1.key?(:span) }
 
       if annotator.single_doc_processing?
         update_job_items(annotator, doc, hdocs.length) if hdocs.any? { _1.key?(:span) }

--- a/app/jobs/obtain_annotations_with_callback_job.rb
+++ b/app/jobs/obtain_annotations_with_callback_job.rb
@@ -16,7 +16,7 @@ class ObtainAnnotationsWithCallbackJob < ApplicationJob
     doc_packer.each do |hdocs, doc, error, slice_count|
       # Handle document slice error
       if error
-        add_exception_message_to_job(doc, error)
+        add_exception_message_to_job(hdocs, error)
         next
       end
 

--- a/app/models/annotation_reception.rb
+++ b/app/models/annotation_reception.rb
@@ -9,12 +9,13 @@ class AnnotationReception < ApplicationRecord
   def process_annotation!(annotations_collection)
     hdoc_metadata.map!(&:deep_symbolize_keys)
 
-    annotations_collection.zip(hdoc_metadata).each do |annotations, hdoc_info|
+    annotations_collection.each_with_index do |annotations, i|
       raise RuntimeError, "Annotation result is not a valid JSON object." unless annotations.is_a?(Hash)
 
       AnnotationUtils.normalize!(annotations)
       annotator.annotations_transform!(annotations)
 
+      hdoc_info = hdoc_metadata[i]
       symbolized_options = options.deep_symbolize_keys.merge(span: hdoc_info[:span])
 
       if symbolized_options[:span].present?

--- a/app/models/annotation_reception.rb
+++ b/app/models/annotation_reception.rb
@@ -29,7 +29,7 @@ class AnnotationReception < ApplicationRecord
       end
     end
 
-    job.increment!(:num_dones, annotations_collection.length)
+    job.increment!(:num_dones)
     job.finish!
   end
 end

--- a/app/models/doc_package.rb
+++ b/app/models/doc_package.rb
@@ -19,8 +19,7 @@ class DocPackage
 
   def hdocs
     if document_too_large?
-      doc = @docs.first
-      slices = doc.get_slices(@max_text_size)
+      slices = slice_document
       slices.map do |slice|
         {
           text: doc.get_text(slice),
@@ -48,8 +47,7 @@ class DocPackage
 
   def calculate_hdoc_count
     if @single_doc_processing && document_too_large?
-      slices = @docs.first.get_slices(@max_text_size)
-      slices.length
+      slice_document.length
     else
       1
     end
@@ -59,5 +57,10 @@ class DocPackage
 
   def document_too_large?
     @docs.length == 1 && @docs.first.body.length > @max_text_size
+  end
+
+  def slice_document
+    doc = @docs.first
+    doc.get_slices(@max_text_size)
   end
 end

--- a/app/models/doc_package.rb
+++ b/app/models/doc_package.rb
@@ -19,6 +19,7 @@ class DocPackage
 
   def hdocs
     if document_too_large?
+      doc = first_doc
       slices = slice_document
       slices.map do |slice|
         {
@@ -60,7 +61,6 @@ class DocPackage
   end
 
   def slice_document
-    doc = @docs.first
-    doc.get_slices(@max_text_size)
+    first_doc.get_slices(@max_text_size)
   end
 end

--- a/app/models/doc_package.rb
+++ b/app/models/doc_package.rb
@@ -46,6 +46,15 @@ class DocPackage
     @docs.first
   end
 
+  def calculate_hdoc_count
+    if @single_doc_processing && document_too_large?
+      slices = @docs.first.get_slices(@max_text_size)
+      slices.length
+    else
+      1
+    end
+  end
+
   private
 
   def document_too_large?

--- a/app/models/doc_packer.rb
+++ b/app/models/doc_packer.rb
@@ -30,7 +30,7 @@ class DocPacker
           end
         end
       rescue RuntimeError => e
-        yield [], doc_package.first_doc, e
+        yield [doc_package.first_doc.hdoc], nil, e
       end
     end
   end

--- a/app/models/doc_packer.rb
+++ b/app/models/doc_packer.rb
@@ -21,9 +21,13 @@ class DocPacker
     @doc_packages.each do |doc_package|
       begin
         if @single_doc_processing
-          process_single_doc(doc_package) { |hdocs, first_doc, error, total_slices| yield hdocs, first_doc, error, total_slices }
+          process_single_doc(doc_package) do |hdocs, doc, error, total_slices|
+            yield hdocs, doc, error, total_slices
+          end
         else
-          process_multiple_docs(doc_package) { |hdocs, first_doc, error, total_slices| yield hdocs, first_doc, error, total_slices }
+          process_multiple_docs(doc_package) do |hdocs, doc, error, total_slices|
+            yield hdocs, doc, error, total_slices
+          end
         end
       rescue RuntimeError => e
         yield [], doc_package.first_doc, e
@@ -31,7 +35,7 @@ class DocPacker
     end
   end
 
-  def hdocs_count
+  def request_count
     @doc_packages.map(&:calculate_hdoc_count).sum
   end
 

--- a/app/models/doc_packer.rb
+++ b/app/models/doc_packer.rb
@@ -27,6 +27,10 @@ class DocPacker
     end
   end
 
+  def hdocs_count
+    @doc_packages.length
+  end
+
   private
 
   def current_doc_package


### PR DESCRIPTION
## 概要
ObtainAnnotationsWithCallbackJob周りのリファクタリングを行いました。

## 行ったこと
- add_exception_message_to_jobの分岐を不要に
- AnnotationReceptionモデルの処理で、zipメソッドを使わない形に変更
- JobのProgress情報がリクエスト数と合っていなかったので修正
- Jobクラスで行っていた `if annotator.single_doc_processing?`以下のロジックをDocPackerクラスに移動

## 動作確認
### 正常動作
リファクタリング前と同じです。
|<img width="998" alt="image" src="https://github.com/user-attachments/assets/4ad034e0-eeea-475a-87fc-7b25f72c3850">|
|:-|

### エラーメッセージ
リファクタリング前と同じです。
|<img width="802" alt="image" src="https://github.com/user-attachments/assets/8a1891b3-7bc4-4c36-90b4-87f191664060">|
|:-|

### sliceメッセージ
リファクタリング前と同じです。
|<img width="797" alt="image" src="https://github.com/user-attachments/assets/ca148787-6d37-4ef6-88bb-80aae5d58b11">|
|:-|

### JobのProgress情報
1. 2つのドキュメントをそれぞれ送っているので2
2. 2つのドキュメントをまとめて送っているので1
3. 1つのドキュメントを2に分割、もう一つのドキュメントを4つに分割してそれぞれ送っているので6
4. 2つのドキュメントをそれぞれ分割して、ドキュメントごとにまとめて送っているので2
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/12078b31-6df6-40f1-b908-11b40f67d56b">
