### PR TITLE
アノテーション投稿APIにClient Credentialによる認証を実装

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -6,4 +6,10 @@ class AccessTokensController < ApplicationController
 
     redirect_back fallback_location: root_path, notice: "Access token was successfully created."
   end
+
+  def destroy
+    current_user.access_token.destroy
+
+    redirect_back fallback_location: root_path, notice: 'Access token was successfully deleted.'
+  end
 end

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,0 +1,9 @@
+class AccessTokensController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    current_user.create_access_token!
+
+    redirect_back fallback_location: root_path, notice: "Access token was successfully created."
+  end
+end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -129,7 +129,7 @@ class AnnotationsController < ApplicationController
 			end
 
 			# for token authentication
-			return unless token_authenticated?
+			return render_token_invalid_error unless token_authenticated?
 		end
 
 		# use unsafe params for flexible paramater passing
@@ -735,7 +735,6 @@ class AnnotationsController < ApplicationController
 			sign_in(token.user)
 			true
 		else
-			render_token_invalid_error
 			false
 		end
 	end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -744,12 +744,12 @@ class AnnotationsController < ApplicationController
 	end
 
 	def token
-		bearer_token = bearer_token_in(request.headers)
+		bearer_token = extract_bearer_token
 		AccessToken.find_by(token: bearer_token) if bearer_token
 	end
 
-	def bearer_token_in(headers)
-		case headers['Authorization']
+	def extract_bearer_token
+		case request.authorization
 		in /^Bearer (.+)$/
 			Regexp.last_match(1)
 		else

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,0 +1,3 @@
+class AccessToken < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,3 +1,10 @@
 class AccessToken < ApplicationRecord
   belongs_to :user
+  before_create :generate_token
+
+  private
+
+  def generate_token
+    self.token = SecureRandom.hex(16)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ActiveRecord::Base
 	has_many :projects, :dependent => :destroy
 	has_many :associate_maintainers, :dependent => :destroy
 	has_many :associate_maintaiain_projects, :through => :associate_maintainers, :source => :project, :class_name => 'Project'
+	has_one :access_token, dependent: :destroy
 	validates :username, :presence => true, :length => {:minimum => 5, :maximum => 20}, uniqueness: true
 	validates_format_of :username, :with => /\A[a-zA-Z0-9][a-zA-Z0-9 _-]+\z/i
 	validate :username_changed, on: :update

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -184,6 +184,7 @@
 					<tr>
 						<th>Access Token</th>
 						<td><%= @user.access_token.token %></td>
+						<td><%= link_to fa_icon('trash'), access_token_path(@user.access_token), method: :delete, data: { confirm: 'Are you sure?' } %></td>
 					</tr>
 				</table>
 			<% else %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -174,6 +174,26 @@
 		-%>
 	</fieldset>
 
+	<% if @user == current_user %>
+		<fieldset class="pane">
+			<legend>Access Token</legend>
+
+			<% if @user.access_token.present? %>
+				<button disabled>Generate Access Token</button>
+				<table>
+					<tr>
+						<th>Access Token</th>
+						<td><%= @user.access_token.token %></td>
+					</tr>
+				</table>
+			<% else %>
+				<%= form_with url: access_tokens_path, method: :post do %>
+					<button type="submit" class="button">Generate Access Token</button>
+				<% end %>
+			<% end %>
+		</fieldset>
+	<% end %>
+
 	<% if @user == current_user && current_user.root? %>
 		<fieldset class="pane">
 			<legend>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Pubann::Application.routes.draw do
 	resources :annotators
 	resources :editors
 
+	resources :access_tokens, only: :create
+
 	devise_for :users, controllers: {
 		:omniauth_callbacks => 'users/omniauth_callbacks',
 		:confirmations => 'confirmations',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Pubann::Application.routes.draw do
 	resources :annotators
 	resources :editors
 
-	resources :access_tokens, only: :create
+	resources :access_tokens, only: %i[create destroy]
 
 	devise_for :users, controllers: {
 		:omniauth_callbacks => 'users/omniauth_callbacks',

--- a/db/migrate/20240910014942_create_access_tokens.rb
+++ b/db/migrate/20240910014942_create_access_tokens.rb
@@ -1,0 +1,10 @@
+class CreateAccessTokens < ActiveRecord::Migration[7.2]
+  def change
+    create_table :access_tokens do |t|
+      t.string :token, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_07_31_020157) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_10_014942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "access_tokens", force: :cascade do |t|
+    t.string "token", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_access_tokens_on_user_id"
+  end
 
   create_table "annotation_receptions", force: :cascade do |t|
     t.string "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -423,6 +431,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_07_31_020157) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "access_tokens", "users"
   add_foreign_key "annotation_receptions", "annotators"
   add_foreign_key "annotation_receptions", "jobs"
   add_foreign_key "annotation_receptions", "projects"


### PR DESCRIPTION
Closes: #134

## 概要
アクセストークン作成/削除機能を追加し、アノテーション投稿APIにClient Credentialによる認証を実装しました。

## 実装内容
- アクセストークンテーブル、モデル作成
- トークン作成機能
- トークン削除機能
- 対象APIにトークン認証機能を追加

## 動作確認
### トークン作成
PubDictionaries同様にユーザーページに実装しました。
|<img width="1199" alt="image" src="https://github.com/user-attachments/assets/4695c264-9aee-427e-88d1-474ef8c9b3e4">|
|:-|

押下時の動作もPubDictionaries同様です。
|<img width="626" alt="image" src="https://github.com/user-attachments/assets/29ba0671-0974-4b64-8dc4-7ffb69ec519c">|
|:-|

### トークン削除
|<img width="744" alt="image" src="https://github.com/user-attachments/assets/1b98dab0-a4f2-49cc-8b50-222136f1e64e">|
|:-|

|<img width="678" alt="image" src="https://github.com/user-attachments/assets/19160291-63da-44db-91ca-f68799257520">|
|:-|


### Client Credential情報を使った認証
#### 正常パターン
以下のリクエストを送信
```
curl -X POST http://localhost:3000/annotations.json \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer 6ea343c73756220d0ff1df968ee497a6" \
  -d '{
    "project_id": "test-project1"
    "text": "This is a sample document text."
  }'

## 応答
{"text":"This is a sample document text."}%
```
機能しています。
|<img width="1003" alt="image" src="https://github.com/user-attachments/assets/c8537144-e5ed-433a-bac3-b3a3cc6e5d2d">|
|:-|

#### トークンが不正な場合
```
curl -X POST http://localhost:3000/annotations.json \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer 123456" \
  -d '{
    "project_id": "test-project1",
    "text": "This is a sample document text."
  }'
{"error":"The access token is missing or invalid."}%
```

### その他
以下の点が問題ないか確認しました。
- トークン作成画面は自身のユーザーページのみ表示される
- 他人のプロジェクトを指定しても操作はできない
  - `{"error":"No project by the name exists under your management."}` 
- TextAEでのリクエストは問題ないか

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/767c50fd-3862-4e8f-83e3-2af222309ddf">