### PR TITLE
アクセストークンのコピーボタンを実装

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
 				$('a[rel*=facebox]').facebox()
 			})
 		</script>
+		<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js"></script>
 		<%= yield :javascript -%>
 		<%= csrf_meta_tags -%>
 	</head>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -183,7 +183,8 @@
 				<table>
 					<tr>
 						<th>Access Token</th>
-						<td><%= @user.access_token.token %></td>
+						<td id="access-token"><%= @user.access_token.token %></td>
+						<td><button id="clipboard-btn" style="cursor: pointer" data-clipboard-target="#access-token"><%= fa_icon('copy') %></button></td>
 						<td><%= link_to fa_icon('trash'), access_token_path(@user.access_token), method: :delete, data: { confirm: 'Are you sure?' } %></td>
 					</tr>
 				</table>
@@ -260,3 +261,7 @@
 	<% end %>
 
 </section>
+
+<script>
+	new ClipboardJS('#clipboard-btn')
+</script>


### PR DESCRIPTION
CDNを利用して、アクセストークン用のコピーボタンを実装しました。

|<img width="534" alt="image" src="https://github.com/user-attachments/assets/e4f26d97-fecc-4b7d-8969-31fb12a0eb5e">|
|:-|

動作問題ないです。
```
## paste
6ea343c73756220d0ff1df968ee497a6
```