### PR TITLE
Recaptcha環境変数を設定していない場合に機能を無効化

### DIFF
--- a/app/controllers/concerns/recaptchable.rb
+++ b/app/controllers/concerns/recaptchable.rb
@@ -1,0 +1,11 @@
+module Recaptchable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :recaptcha_usable?
+  end
+
+  def recaptcha_usable?
+    ENV['RECAPTCHA_SITE_KEY'].present? && ENV['RECAPTCHA_SECRET_KEY'].present?
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,5 +1,7 @@
 class Users::PasswordsController < Devise::PasswordsController
-  before_action :validate_recaptcha, only: [:create]
+  include Recaptchable
+
+  before_action :validate_recaptcha, only: [:create], if: :recaptcha_usable?
 
   private
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,8 @@
 class Users::RegistrationsController < Devise::RegistrationsController
+  include Recaptchable
+
   before_action :configure_permitted_parameters
-  before_action :validate_recaptcha, only: [:create]
+  before_action :validate_recaptcha, only: [:create], if: :recaptcha_usable?
 
   protected
     def configure_permitted_parameters

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -16,10 +16,12 @@
   	<th><%= f.label :login %></th>
   	<td><%= f.text_field :login, :placeholder => "Your username or e-mail address" %></td>
   </tr>
-  <tr>
-    <th></th>
-    <td><%= recaptcha_tags %></td>
-  </tr>
+  <% if recaptcha_usable? %>
+    <tr>
+      <th></th>
+      <td><%= recaptcha_tags %></td>
+    </tr>
+  <% end %>
   <tr>
   	<th colspan="2" style="text-align:center"><%= f.submit t('views.users.send_reset_password_instructions') %></th>
   </tr>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -47,11 +47,13 @@
         <td><%= f.password_field :password_confirmation %></td>
         <td></td>
       </tr>
-      <tr>
-        <th></th>
-        <td><%= recaptcha_tags %></td>
-        <td></td>
-      </tr>
+      <% if recaptcha_usable? %>
+        <tr>
+          <th></th>
+          <td><%= recaptcha_tags %></td>
+          <td></td>
+        </tr>
+      <% end %>
       <tr>
         <th colspan="3" style="text-align:center"><%= f.submit t('views.users.sign_up'), :class => 'capitalize_first' %></th>
       </tr>


### PR DESCRIPTION
## 概要
PubDictionariesに行った修正と同様に、Recaptcha環境変数を設定していない場合に機能を無効化しました。

[PubDictionariesのPR](https://github.com/pubannotation/pubdictionaries/pull/135)

## 実装内容
- recaptcha環境変数が設定されていない場合に、以下の機能を無効化
  - viewでの表示
  - controllerでの認証

## 動作確認
以下の点を確認しました。
- 環境変数が設定されていない場合
  - recaptchaビューが表示されない
  - recatpcha認証不要で機能が動作する
- 環境変数が設定されている場合
  - recaptchaビューが表示される
  - repcaptcha認証が必要になる

### 環境変数が設定されていない場合
#### recaptchaビューが表示されない
users/sign_up
|<img width="677" alt="image" src="https://github.com/user-attachments/assets/0ebe5fb2-94f7-497a-a1a8-34f4ceed2348">|
|:-|

users/password/new
|<img width="654" alt="image" src="https://github.com/user-attachments/assets/17d5205e-aa97-4ab1-80c4-493439a1f107">|
|:-|

#### recatpcha認証不要で機能が動作する
users/sign_up
|<img width="1080" alt="image" src="https://github.com/user-attachments/assets/540d31a3-4487-4bf7-895d-31516f25de56">|
|:-|

users/password/new
|<img width="766" alt="image" src="https://github.com/user-attachments/assets/8bc02f30-07ba-4080-b47c-ad7303bc2d6a">|
|:-|

### 環境変数が設定されている場合
#### recaptchaビューが表示される
|<img width="640" alt="image" src="https://github.com/user-attachments/assets/213c0a9f-bafe-48c2-afb3-a9b20a74d171">|
|:-|

|<img width="674" alt="image" src="https://github.com/user-attachments/assets/36c24cb5-0b56-4bae-b67c-3195ebe94818">|
|:-|

#### repcaptcha認証が必要になる
|<img width="1064" alt="image" src="https://github.com/user-attachments/assets/fb6acbbe-812b-4f00-ad2c-92eda871989a">|
|:-|

|<img width="656" alt="image" src="https://github.com/user-attachments/assets/74010461-0ed5-475e-9ea2-b61e8a845ff7">|
|:-|