### PR TITLE
App-Name HTTPヘッダーを用いてTextAEを識別するように変更

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -121,7 +121,7 @@ class AnnotationsController < ApplicationController
 	def create
 		unless user_signed_in?
 			# for TextAE
-			if request.headers['Origin'] == 'https://textae.pubannotation.org'
+			if request.headers['App-Name'] == 'TextAE'
 				response.headers['WWW-Authenticate'] = 'ServerPage'
 				response.headers['Location'] = new_user_session_url
 				response.headers['Access-Control-Expose-Headers'] = 'WWW-Authenticate, Location'


### PR DESCRIPTION
## 概要
App-Name HTTPヘッダーを用いてTextAEを識別するように変更しました。

## 実装内容
- アノテーションコントローラーでのTextAEの識別方法を`Origin`ヘッダーから`App-Name`ヘッダーに変更

## 動作確認
`request.headers['App-Name'] `が取得でき、未ログイン時に正しく条件分岐が機能することを確認しました。
```
15:55:03 web.1    |    120|   # POST /annotations.json
15:55:03 web.1    |    121|   def create
15:55:03 web.1    |    122|     unless user_signed_in?
15:55:03 web.1    |    123|       # for TextAE
15:55:03 web.1    |    124|       if request.headers['App-Name'] == 'TextAE'
15:55:03 web.1    | => 125|         binding.break
15:55:03 web.1    |    126|         response.headers['WWW-Authenticate'] = 'ServerPage'
15:55:03 web.1    |    127|         response.headers['Location'] = new_user_session_url
15:55:03 web.1    |    128|         response.headers['Access-Control-Expose-Headers'] = 'WWW-Authenticate, Location'
15:55:03 web.1    |    129|         head 401 and return
15:55:03 web.1    | =>#0 AnnotationsController#create at ~/develop/pubannotation/app/controllers/annotations_controller.rb:125
15:55:03 web.1    |   #1 ActionController::BasicImplicitRender#send_action(method="create", args=[]) at ~/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/actionpack-7.2.1/lib/action_controller/metal/basic_implicit_render.rb:8
15:55:03 web.1    |   # and 75 frames (use `bt' command for all frames)
(ruby)  request.headers['App-Name']
"TextAE"
```