### PR TITLE
Updated faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,7 @@ gem 'rubyzip'
 gem 'zip-zip'
 gem 'elasticsearch-model', '~> 7.2'
 gem 'elasticsearch-rails', '~> 7.2'
-# Currently released elasticsearch-model depends on a specific verions of faraday
-# See: https://github.com/uken/fluent-plugin-elasticsearch/issues/699
-gem 'faraday', '~> 1.10'
+gem 'faraday'
 gem 'stardog-rb', git: 'https://github.com/jdkim/stardog-rb.git'
 gem 'tao_rdfizer', '~> 0.11.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,29 +169,12 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.2)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday (2.12.0)
+      faraday-net_http (>= 2.0, < 3.4)
+      json
+      logger
+    faraday-net_http (3.3.0)
+      net-http
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     font-awesome-rails (4.7.0.8)
@@ -216,6 +199,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.7.2)
     jwt (2.8.2)
       base64
     kaminari (1.2.2)
@@ -251,7 +235,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
-    multipart-post (2.4.1)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.17)
       date
       net-protocol
@@ -379,7 +364,6 @@ GEM
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
     ruby-dictionary (1.1.1)
-    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -425,6 +409,7 @@ GEM
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    uri (0.13.1)
     useragent (0.16.10)
     version_gem (1.1.4)
     warden (1.2.9)
@@ -463,7 +448,7 @@ DEPENDENCIES
   elasticsearch-rails (~> 7.2)
   facebox-rails!
   factory_bot_rails
-  faraday (~> 1.10)
+  faraday
   font-awesome-rails
   foreman
   friendly_id


### PR DESCRIPTION
## 概要
faraday gemをアップデートしました。

## 行ったこと
- faraday gemを1.10.3から2.12.0にアップデート

PubAnnotationでは、`Elasticsearch Rails 7`と`net-http-persistent`を同時に使う処理は無かったため、エラーは特に発生しませんでした。

## 動作確認
### サーバーが起動できる
foremanでのサーバー起動
![image](https://github.com/user-attachments/assets/a4ffafc5-8ee8-494c-b207-0039b1c52565)

### Faradayの動作確認
PubAnnotationでFaradayを使用している箇所は、以下のみでした。
https://github.com/pubannotation/pubannotation/blob/4c22a49e180896690e561bf06be5f00b85cbe0e7/app/models/annotator.rb#L109

ObtainAnnotationsJobを実行すると上記のメソッドが呼ばれます。
実行した結果、レスポンスとして201が返ってきているのが確認できるため、Faraday自体の動作は問題ないと思います。
|<img width="845" alt="image" src="https://github.com/user-attachments/assets/9cc5e72b-7618-463f-bcd7-3e9d6c672ff5">|
|:-|