### PR TITLE
アノテーションリクエスト時のadd/mergeモードの不具合を修正

### DIFF
--- a/app/models/align_text_in_ractor.rb
+++ b/app/models/align_text_in_ractor.rb
@@ -28,8 +28,8 @@ class AlignTextInRactor
 
         original_annotation.merge!({
                                      text: input_chunk.ref_text,
-                                     denotations: aligned_annotation.denotations,
-                                     blocks: aligned_annotation.blocks
+                                     denotations: aligned_annotation.denotations.map {_1.dup},
+                                     blocks: aligned_annotation.blocks.map {_1.dup}
                                    })
         original_annotation.delete_if { |_, v| !v.present? }
 

--- a/app/models/store_annotations_collection.rb
+++ b/app/models/store_annotations_collection.rb
@@ -15,12 +15,15 @@ class StoreAnnotationsCollection
     result = aligner.call
     @warnings.concat result.warnings
 
+    # To avoid frozen error in after process, make a deep copy for result.
+    dup_result = Marshal.load(Marshal.dump(result))
+
     Thread.new do
-      result.annotations_for_doc_collection.each do |annotations_for_doc|
+      dup_result.annotations_for_doc_collection.each do |annotations_for_doc|
         @project.pretreatment_according_to(@options, annotations_for_doc)
       end
 
-      valid_annotations = result.annotations_for_doc_collection.reduce([]) do |valid_annotations, annotations_for_doc|
+      valid_annotations = dup_result.annotations_for_doc_collection.reduce([]) do |valid_annotations, annotations_for_doc|
         valid_annotations + annotations_for_doc.annotations.filter.with_index do |annotation, index|
           inspect_annotations @warnings,
                               annotation,

--- a/app/models/store_annotations_collection.rb
+++ b/app/models/store_annotations_collection.rb
@@ -15,15 +15,12 @@ class StoreAnnotationsCollection
     result = aligner.call
     @warnings.concat result.warnings
 
-    # To avoid frozen error in after process, make a deep copy for result.
-    dup_result = Marshal.load(Marshal.dump(result))
-
     Thread.new do
-      dup_result.annotations_for_doc_collection.each do |annotations_for_doc|
+      result.annotations_for_doc_collection.each do |annotations_for_doc|
         @project.pretreatment_according_to(@options, annotations_for_doc)
       end
 
-      valid_annotations = dup_result.annotations_for_doc_collection.reduce([]) do |valid_annotations, annotations_for_doc|
+      valid_annotations = result.annotations_for_doc_collection.reduce([]) do |valid_annotations, annotations_for_doc|
         valid_annotations + annotations_for_doc.annotations.filter.with_index do |annotation, index|
           inspect_annotations @warnings,
                               annotation,


### PR DESCRIPTION
Closes: #127

## 概要
アノテーションリクエストの際、addまたはmergeモードを指定するとFrozenErrorが発生する問題があります。
[該当issue](https://github.com/pubannotation/pubannotation/issues/127)

この問題を修正しました。

## 行ったこと
- freezeされたアノテーション結果をディープコピーしたものに置き換え

## 動作確認
### Addモードが動作する
次の状態のドキュメントに対して、辞書をhappyという単語のみに置き換えてaddモードで実行します。
<img width="1360" alt="image" src="https://github.com/user-attachments/assets/c13055bf-83b0-4c47-b0c7-99301ba39a4a">

happyにアノテーションが追加されました。
<img width="1347" alt="image" src="https://github.com/user-attachments/assets/b9aa3c8a-222b-4219-b229-6b4cec2e0589">

### Mergeモードが動作する
Addモードで追加した状態のドキュメントに対して、次の辞書の状態でMergeモードで実行します。
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/04952cf1-06db-4e74-9b37-a85f7203a1f7">

アノテーションがマージされました。
<img width="1339" alt="image" src="https://github.com/user-attachments/assets/746c8746-4edb-4598-9804-a1c6b6b29e58">


