### PR TITLE
Implement SimpleInlineTextAnnotation parser

### DIFF
--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -6,4 +6,18 @@ class SimpleInlineTextAnnotation
   # [Label1]: URL1
   # [Label2]: URL2
   ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:^\[[^\]]+\]:\s+.+\n)+)/
+
+  def initialize(text, denotations, config = nil)
+    @text = text
+    @denotations = denotations
+    @config = config
+  end
+
+  def to_h
+    {
+      text: @text,
+      denotation: @denotations.map(&:to_h),
+      config: @config
+    }.compact
+  end
 end

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -18,7 +18,8 @@ class SimpleInlineTextAnnotation
   end
 
   def self.parse(source)
-    SimpleInlineTextAnnotation::Parser.new(source).parse
+    result = SimpleInlineTextAnnotation::Parser.new(source).parse
+    result.to_h
   end
 
   def to_h

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -13,6 +13,10 @@ class SimpleInlineTextAnnotation
     @config = config
   end
 
+  def self.parse(source)
+    SimpleInlineTextAnnotation::Parser.new(source).parse
+  end
+
   def to_h
     {
       text: @text,

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -47,8 +47,8 @@ class SimpleInlineTextAnnotation
     text.gsub(ESCAPE_PATTERN, '')
   end
 
+  # Reduce consecutive newlines to a single newline.
   def reduce_consecutive_newlines_from(text)
-    # Replaces consecutive newlines to a single newline.
     text.gsub(/\n{2,}/, "\n\n")
   end
 

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -33,18 +33,17 @@ class SimpleInlineTextAnnotation
   private
 
   def format_text(text)
-    result = exclude_escape_backslash_from(text)
+    result = remove_escape_backslash_from(text)
     result = reduce_consecutive_newlines_from(result)
 
     result
   end
 
-  def exclude_escape_backslash_from(text)
-    # Remove backslashes used to escape inline annotation format.
-    # For example, `\[Elon Musk][Person]` is treated as plain text
-    # rather than an annotation. This method removes the leading
-    # backslash and keeps the text as `[Elon Musk][Person]`.
-
+  # Remove backslashes used to escape inline annotation format.
+  # For example, `\[Elon Musk][Person]` is treated as plain text
+  # rather than an annotation. This method removes the leading
+  # backslash and keeps the text as `[Elon Musk][Person]`.
+  def remove_escape_backslash_from(text)
     text.gsub(ESCAPE_PATTERN, '')
   end
 

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -1,0 +1,9 @@
+class SimpleInlineTextAnnotation
+  # ENTITY_TYPE_BLOCK_PATTERN matches a block of the entity type definitions.
+  # Requires a blank line above the block definition.
+  # Example:
+  #
+  # [Label1]: URL1
+  # [Label2]: URL2
+  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:^\[[^\]]+\]:\s+.+\n)+)/
+end

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -7,10 +7,14 @@ class SimpleInlineTextAnnotation
   # [Label2]: URL2
   ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:^\[[^\]]+\]:\s+.+\n)+)/
 
-  def initialize(text, denotations, config = nil)
+  # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
+  # Example: \[This is a part of][original text]
+  ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/
+
+  def initialize(text, denotations, entity_type_collection)
     @text = text
     @denotations = denotations
-    @config = config
+    @entity_type_collection = entity_type_collection
   end
 
   def self.parse(source)
@@ -19,9 +23,26 @@ class SimpleInlineTextAnnotation
 
   def to_h
     {
-      text: @text,
+      text: text_without_escape_backslash(@text),
       denotation: @denotations.map(&:to_h),
-      config: @config
+      config: config
     }.compact
+  end
+
+  private
+
+  def text_without_escape_backslash(text)
+    # Remove backslashes used to escape inline annotation format.
+    # For example, `\[Elon Musk][Person]` is treated as plain text
+    # rather than an annotation. This method removes the leading
+    # backslash and keeps the text as `[Elon Musk][Person]`.
+
+    text.gsub(ESCAPE_PATTERN, '')
+  end
+
+  def config
+    return nil unless @entity_type_collection.any?
+
+    { "entity types": @entity_type_collection.to_config }
   end
 end

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -24,7 +24,7 @@ class SimpleInlineTextAnnotation
 
   def to_h
     {
-      text: text_without_escape_backslash(@text),
+      text: format_text(@text),
       denotation: @denotations.map(&:to_h),
       config: config
     }.compact
@@ -32,13 +32,25 @@ class SimpleInlineTextAnnotation
 
   private
 
-  def text_without_escape_backslash(text)
+  def format_text(text)
+    result = exclude_escape_backslash_from(text)
+    result = reduce_consecutive_newlines_from(result)
+
+    result
+  end
+
+  def exclude_escape_backslash_from(text)
     # Remove backslashes used to escape inline annotation format.
     # For example, `\[Elon Musk][Person]` is treated as plain text
     # rather than an annotation. This method removes the leading
     # backslash and keeps the text as `[Elon Musk][Person]`.
 
     text.gsub(ESCAPE_PATTERN, '')
+  end
+
+  def reduce_consecutive_newlines_from(text)
+    # Replaces consecutive newlines to a single newline.
+    text.gsub(/\n{2,}/, "\n\n")
   end
 
   def config

--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -1,10 +1,12 @@
-class SimpleInlineTextAnnotation::Denotation
-  def initialize(begin_pos, end_pos, obj)
-    @span = { begin: begin_pos, end: end_pos }
-    @obj = obj
-  end
+class SimpleInlineTextAnnotation
+  class Denotation
+    def initialize(begin_pos, end_pos, obj)
+      @span = { begin: begin_pos, end: end_pos }
+      @obj = obj
+    end
 
-  def to_h
-    { span: @span, obj: @obj }
+    def to_h
+      { span: @span, obj: @obj }
+    end
   end
 end

--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -1,0 +1,12 @@
+class SimpleInlineTextAnnotation
+  class Denotation
+    def initialize(begin_pos, end_pos, obj)
+      @span = { begin: begin_pos, end: end_pos }
+      @obj = obj
+    end
+
+    def to_h
+      { span: @span, obj: @obj }
+    end
+  end
+end

--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -1,12 +1,10 @@
-class SimpleInlineTextAnnotation
-  class Denotation
-    def initialize(begin_pos, end_pos, obj)
-      @span = { begin: begin_pos, end: end_pos }
-      @obj = obj
-    end
+class SimpleInlineTextAnnotation::Denotation
+  def initialize(begin_pos, end_pos, obj)
+    @span = { begin: begin_pos, end: end_pos }
+    @obj = obj
+  end
 
-    def to_h
-      { span: @span, obj: @obj }
-    end
+  def to_h
+    { span: @span, obj: @obj }
   end
 end

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -12,6 +12,12 @@ class SimpleInlineTextAnnotation
       entity_types[label]
     end
 
+    # to_config returns a Array of hashes of each entity type.
+    # Example:
+    #   [
+    #     {id: "https://example.com/Person", label: "Person"},
+    #     {id: "https://example.com/Organization", label: "Organization"}
+    #   ]
     def to_config
       entity_types.map do |label, id|
         { id: id, label: label }

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -30,23 +30,13 @@ class SimpleInlineTextAnnotation
 
     private
 
+    # entity_types returns a Hash structured with label as key and id as value.
+    # Example:
+    #   {
+    #     "Person": "https://example.com/Person",
+    #     "Organization": "https://example.com/Organization"
+    #   }
     def entity_types
-      # entity_type is a Hash structured with label as key and id as value.
-
-      # Structure:
-      #   Key: Label (String) - The label defined within square brackets (e.g., "Person").
-      #   Value: ID (String)  - The URL or value following the colon (e.g., "https://example.com/Person").
-
-      # Example Input (Source):
-      #   [Person]: https://example.com/Person
-      #   [Organization]: https://example.com/Organization
-
-      # Example Output (Hash):
-      #   {
-      #     "Person": "https://example.com/Person",
-      #     "Organization": "https://example.com/Organization"
-      #   }
-
       @entity_types ||= read_entities_from_source
     end
 

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -45,16 +45,12 @@ class SimpleInlineTextAnnotation::EntityTypeCollection
     @source.scan(SimpleInlineTextAnnotation::ENTITY_TYPE_BLOCK_PATTERN).each do |entity_block|
       entity_block[0].each_line do |line|
         match = line.strip.match(ENTITY_TYPE_PATTERN)
+        next unless match
 
-        if match
-          if match[1] == match[2]
-            # Do not create entity_type if label and id is same.
-            next
-          else
-            label, id = match[1], match[2]
-            entity_types[label] ||= id
-          end
-        end
+        label, id = match[1], match[2]
+        next if label == id # Do not create entity_type if label and id is same.
+
+        entity_types[label] ||= id
       end
     end
 

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -42,8 +42,8 @@ class SimpleInlineTextAnnotation::EntityTypeCollection
   def read_entities_from_source
     entity_types = {}
 
-    @source.scan(SimpleInlineTextAnnotation::ENTITY_TYPE_BLOCK_PATTERN).each do |block|
-      block[0].each_line do |line|
+    @source.scan(SimpleInlineTextAnnotation::ENTITY_TYPE_BLOCK_PATTERN).each do |entity_block|
+      entity_block[0].each_line do |line|
         match = line.strip.match(ENTITY_TYPE_PATTERN)
 
         if match

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -47,8 +47,13 @@ class SimpleInlineTextAnnotation::EntityTypeCollection
         match = line.strip.match(ENTITY_TYPE_PATTERN)
 
         if match
-          label, id = match[1], match[2]
-          entity_types[label] ||= id
+          if match[1] == match[2]
+            # Do not create entity_type if label and id is same.
+            next
+          else
+            label, id = match[1], match[2]
+            entity_types[label] ||= id
+          end
         end
       end
     end

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -1,0 +1,64 @@
+class SimpleInlineTextAnnotation
+  class EntityTypeCollection
+    # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
+    # Example: [Label]: URL
+    ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(.*)/
+
+    def initialize(source)
+      @source = source
+    end
+
+    def get(label)
+      entity_types[label]
+    end
+
+    def to_config
+      entity_types.map do |label, id|
+        { id: id, label: label }
+      end
+    end
+
+    def any?
+      entity_types.any?
+    end
+
+    private
+
+    def entity_types
+      # entity_type is a Hash structured with label as key and id as value.
+
+      # Structure:
+      #   Key: Label (String) - The label defined within square brackets (e.g., "Person").
+      #   Value: ID (String)  - The URL or value following the colon (e.g., "https://example.com/Person").
+
+      # Example Input (Source):
+      #   [Person]: https://example.com/Person
+      #   [Organization]: https://example.com/Organization
+
+      # Example Output (Hash):
+      #   {
+      #     "Person": "https://example.com/Person",
+      #     "Organization": "https://example.com/Organization"
+      #   }
+
+      @entity_types ||= read_entities_from_source
+    end
+
+    def read_entities_from_source
+      entity_types = {}
+
+      @source.scan(ENTITY_TYPE_BLOCK_PATTERN).each do |block|
+        block[0].each_line do |line|
+          match = line.strip.match(ENTITY_TYPE_PATTERN)
+
+          if match
+            label, id = match[1], match[2]
+            entity_types[label] ||= id
+          end
+        end
+      end
+
+      entity_types
+    end
+  end
+end

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -1,60 +1,58 @@
-class SimpleInlineTextAnnotation
-  class EntityTypeCollection
-    # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
-    # Example: [Label]: URL
-    ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(.*)/
+class SimpleInlineTextAnnotation::EntityTypeCollection
+  # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
+  # Example: [Label]: URL
+  ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(.*)/
 
-    def initialize(source)
-      @source = source
+  def initialize(source)
+    @source = source
+  end
+
+  def get(label)
+    entity_types[label]
+  end
+
+  # to_config returns a Array of hashes of each entity type.
+  # Example:
+  #   [
+  #     {id: "https://example.com/Person", label: "Person"},
+  #     {id: "https://example.com/Organization", label: "Organization"}
+  #   ]
+  def to_config
+    entity_types.map do |label, id|
+      { id: id, label: label }
     end
+  end
 
-    def get(label)
-      entity_types[label]
-    end
+  def any?
+    entity_types.any?
+  end
 
-    # to_config returns a Array of hashes of each entity type.
-    # Example:
-    #   [
-    #     {id: "https://example.com/Person", label: "Person"},
-    #     {id: "https://example.com/Organization", label: "Organization"}
-    #   ]
-    def to_config
-      entity_types.map do |label, id|
-        { id: id, label: label }
-      end
-    end
+  private
 
-    def any?
-      entity_types.any?
-    end
+  # entity_types returns a Hash structured with label as key and id as value.
+  # Example:
+  #   {
+  #     "Person": "https://example.com/Person",
+  #     "Organization": "https://example.com/Organization"
+  #   }
+  def entity_types
+    @entity_types ||= read_entities_from_source
+  end
 
-    private
+  def read_entities_from_source
+    entity_types = {}
 
-    # entity_types returns a Hash structured with label as key and id as value.
-    # Example:
-    #   {
-    #     "Person": "https://example.com/Person",
-    #     "Organization": "https://example.com/Organization"
-    #   }
-    def entity_types
-      @entity_types ||= read_entities_from_source
-    end
+    @source.scan(SimpleInlineTextAnnotation::ENTITY_TYPE_BLOCK_PATTERN).each do |block|
+      block[0].each_line do |line|
+        match = line.strip.match(ENTITY_TYPE_PATTERN)
 
-    def read_entities_from_source
-      entity_types = {}
-
-      @source.scan(ENTITY_TYPE_BLOCK_PATTERN).each do |block|
-        block[0].each_line do |line|
-          match = line.strip.match(ENTITY_TYPE_PATTERN)
-
-          if match
-            label, id = match[1], match[2]
-            entity_types[label] ||= id
-          end
+        if match
+          label, id = match[1], match[2]
+          entity_types[label] ||= id
         end
       end
-
-      entity_types
     end
+
+    entity_types
   end
 end

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -1,59 +1,61 @@
-class SimpleInlineTextAnnotation::EntityTypeCollection
-  # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
-  # Example: [Label]: URL
-  ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(.*)/
+class SimpleInlineTextAnnotation
+  class EntityTypeCollection
+    # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
+    # Example: [Label]: URL
+    ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(.*)/
 
-  def initialize(source)
-    @source = source
-  end
-
-  def get(label)
-    entity_types[label]
-  end
-
-  # to_config returns a Array of hashes of each entity type.
-  # Example:
-  #   [
-  #     {id: "https://example.com/Person", label: "Person"},
-  #     {id: "https://example.com/Organization", label: "Organization"}
-  #   ]
-  def to_config
-    entity_types.map do |label, id|
-      { id: id, label: label }
+    def initialize(source)
+      @source = source
     end
-  end
 
-  def any?
-    entity_types.any?
-  end
+    def get(label)
+      entity_types[label]
+    end
 
-  private
-
-  # entity_types returns a Hash structured with label as key and id as value.
-  # Example:
-  #   {
-  #     "Person": "https://example.com/Person",
-  #     "Organization": "https://example.com/Organization"
-  #   }
-  def entity_types
-    @entity_types ||= read_entities_from_source
-  end
-
-  def read_entities_from_source
-    entity_types = {}
-
-    @source.scan(SimpleInlineTextAnnotation::ENTITY_TYPE_BLOCK_PATTERN).each do |entity_block|
-      entity_block[0].each_line do |line|
-        match = line.strip.match(ENTITY_TYPE_PATTERN)
-        next unless match
-
-        label, id = match[1], match[2]
-        next if label == id # Do not create entity_type if label and id is same.
-
-        entity_types[label] ||= id
+    # to_config returns a Array of hashes of each entity type.
+    # Example:
+    #   [
+    #     {id: "https://example.com/Person", label: "Person"},
+    #     {id: "https://example.com/Organization", label: "Organization"}
+    #   ]
+    def to_config
+      entity_types.map do |label, id|
+        { id: id, label: label }
       end
     end
 
-    entity_types
+    def any?
+      entity_types.any?
+    end
+
+    private
+
+    # entity_types returns a Hash structured with label as key and id as value.
+    # Example:
+    #   {
+    #     "Person": "https://example.com/Person",
+    #     "Organization": "https://example.com/Organization"
+    #   }
+    def entity_types
+      @entity_types ||= read_entities_from_source
+    end
+
+    def read_entities_from_source
+      entity_types = {}
+
+      @source.scan(ENTITY_TYPE_BLOCK_PATTERN).each do |entity_block|
+        entity_block[0].each_line do |line|
+          match = line.strip.match(ENTITY_TYPE_PATTERN)
+          next unless match
+
+          label, id = match[1], match[2]
+          next if label == id # Do not create entity_type if label and id is same.
+
+          entity_types[label] ||= id
+        end
+      end
+
+      entity_types
+    end
   end
 end

--- a/app/models/simple_inline_text_annotation/parser.rb
+++ b/app/models/simple_inline_text_annotation/parser.rb
@@ -32,11 +32,11 @@ class SimpleInlineTextAnnotation
         full_text[match.begin(0)...match.end(0)] = target_text
       end
 
-      {
-        text: text_without_escape_backslash(full_text),
-        denotation: @denotations.map(&:to_h),
-        config: config
-      }.compact
+      SimpleInlineTextAnnotation.new(
+        text_without_escape_backslash(full_text),
+        @denotations.map(&:to_h),
+        config
+      ).to_h
     end
 
     private

--- a/app/models/simple_inline_text_annotation/parser.rb
+++ b/app/models/simple_inline_text_annotation/parser.rb
@@ -1,71 +1,69 @@
-class SimpleInlineTextAnnotation
-  class Parser
-    # DENOTATION_PATTERN matches two consecutive pairs of square brackets.
-    # Example: [Annotated Text][Label]
-    DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/
+class SimpleInlineTextAnnotation::Parser
+  # DENOTATION_PATTERN matches two consecutive pairs of square brackets.
+  # Example: [Annotated Text][Label]
+  DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/
 
-    # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
-    # Example: \[This is a part of][original text]
-    ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/
+  # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
+  # Example: \[This is a part of][original text]
+  ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/
 
-    def initialize(source)
-      @source = source.dup.freeze
-      @denotations = []
-      @entity_type_collection = SimpleInlineTextAnnotation::EntityTypeCollection.new(source)
+  def initialize(source)
+    @source = source.dup.freeze
+    @denotations = []
+    @entity_type_collection = SimpleInlineTextAnnotation::EntityTypeCollection.new(source)
+  end
+
+  def parse
+    full_text = source_without_references
+
+    while full_text =~ DENOTATION_PATTERN
+      match = Regexp.last_match
+      target_text = match[1]
+      label = match[2]
+
+      begin_pos = match.begin(0)
+      end_pos = begin_pos + target_text.length - 1 # -1 to adapt with zero-based indexing.
+      obj = get_obj_for(label)
+
+      @denotations << SimpleInlineTextAnnotation::Denotation.new(begin_pos, end_pos, obj)
+
+      # Replace the processed annotation with its text content
+      full_text[match.begin(0)...match.end(0)] = target_text
     end
 
-    def parse
-      full_text = source_without_references
+    SimpleInlineTextAnnotation.new(
+      text_without_escape_backslash(full_text),
+      @denotations.map(&:to_h),
+      config
+    ).to_h
+  end
 
-      while full_text =~ DENOTATION_PATTERN
-        match = Regexp.last_match
-        target_text = match[1]
-        label = match[2]
+  private
 
-        begin_pos = match.begin(0)
-        end_pos = begin_pos + target_text.length - 1 # -1 to adapt with zero-based indexing.
-        obj = get_obj_for(label)
+  def source_without_references
+    # Remove references from the source.
 
-        @denotations << SimpleInlineTextAnnotation::Denotation.new(begin_pos, end_pos, obj)
+    @source.gsub(SimpleInlineTextAnnotation::ENTITY_TYPE_BLOCK_PATTERN) do |block|
+      block.start_with?("\n\n") ? "\n\n" : ""
+    end.strip
+  end
 
-        # Replace the processed annotation with its text content
-        full_text[match.begin(0)...match.end(0)] = target_text
-      end
+  def get_obj_for(label)
+    @entity_type_collection.get(label) || label
+  end
 
-      SimpleInlineTextAnnotation.new(
-        text_without_escape_backslash(full_text),
-        @denotations.map(&:to_h),
-        config
-      ).to_h
-    end
+  def text_without_escape_backslash(text)
+    # Remove backslashes used to escape inline annotation format.
+    # For example, `\[Elon Musk][Person]` is treated as plain text
+    # rather than an annotation. This method removes the leading
+    # backslash and keeps the text as `[Elon Musk][Person]`.
 
-    private
+    text.gsub(ESCAPE_PATTERN, '')
+  end
 
-    def source_without_references
-      # Remove references from the source.
+  def config
+    return nil unless @entity_type_collection.any?
 
-      @source.gsub(ENTITY_TYPE_BLOCK_PATTERN) do |block|
-        block.start_with?("\n\n") ? "\n\n" : ""
-      end.strip
-    end
-
-    def get_obj_for(label)
-      @entity_type_collection.get(label) || label
-    end
-
-    def text_without_escape_backslash(text)
-      # Remove backslashes used to escape inline annotation format.
-      # For example, `\[Elon Musk][Person]` is treated as plain text
-      # rather than an annotation. This method removes the leading
-      # backslash and keeps the text as `[Elon Musk][Person]`.
-
-      text.gsub(ESCAPE_PATTERN, '')
-    end
-
-    def config
-      return nil unless @entity_type_collection.any?
-
-      { "entity types": @entity_type_collection.to_config }
-    end
+    { "entity types": @entity_type_collection.to_config }
   end
 end

--- a/app/models/simple_inline_text_annotation/parser.rb
+++ b/app/models/simple_inline_text_annotation/parser.rb
@@ -3,10 +3,6 @@ class SimpleInlineTextAnnotation::Parser
   # Example: [Annotated Text][Label]
   DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/
 
-  # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
-  # Example: \[This is a part of][original text]
-  ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/
-
   def initialize(source)
     @source = source.dup.freeze
     @denotations = []
@@ -32,9 +28,9 @@ class SimpleInlineTextAnnotation::Parser
     end
 
     SimpleInlineTextAnnotation.new(
-      text_without_escape_backslash(full_text),
-      @denotations.map(&:to_h),
-      config
+      full_text,
+      @denotations,
+      @entity_type_collection
     ).to_h
   end
 
@@ -50,20 +46,5 @@ class SimpleInlineTextAnnotation::Parser
 
   def get_obj_for(label)
     @entity_type_collection.get(label) || label
-  end
-
-  def text_without_escape_backslash(text)
-    # Remove backslashes used to escape inline annotation format.
-    # For example, `\[Elon Musk][Person]` is treated as plain text
-    # rather than an annotation. This method removes the leading
-    # backslash and keeps the text as `[Elon Musk][Person]`.
-
-    text.gsub(ESCAPE_PATTERN, '')
-  end
-
-  def config
-    return nil unless @entity_type_collection.any?
-
-    { "entity types": @entity_type_collection.to_config }
   end
 end

--- a/app/models/simple_inline_text_annotation/parser.rb
+++ b/app/models/simple_inline_text_annotation/parser.rb
@@ -31,7 +31,7 @@ class SimpleInlineTextAnnotation::Parser
       full_text,
       @denotations,
       @entity_type_collection
-    ).to_h
+    )
   end
 
   private

--- a/app/models/simple_inline_text_annotation/parser.rb
+++ b/app/models/simple_inline_text_annotation/parser.rb
@@ -1,0 +1,71 @@
+class SimpleInlineTextAnnotation
+  class Parser
+    # DENOTATION_PATTERN matches two consecutive pairs of square brackets.
+    # Example: [Annotated Text][Label]
+    DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/
+
+    # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
+    # Example: \[This is a part of][original text]
+    ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/
+
+    def initialize(source)
+      @source = source.dup.freeze
+      @denotations = []
+      @entity_type_collection = SimpleInlineTextAnnotation::EntityTypeCollection.new(source)
+    end
+
+    def parse
+      full_text = source_without_references
+
+      while full_text =~ DENOTATION_PATTERN
+        match = Regexp.last_match
+        target_text = match[1]
+        label = match[2]
+
+        begin_pos = match.begin(0)
+        end_pos = begin_pos + target_text.length - 1 # -1 to adapt with zero-based indexing.
+        obj = get_obj_for(label)
+
+        @denotations << SimpleInlineTextAnnotation::Denotation.new(begin_pos, end_pos, obj)
+
+        # Replace the processed annotation with its text content
+        full_text[match.begin(0)...match.end(0)] = target_text
+      end
+
+      {
+        text: text_without_escape_backslash(full_text),
+        denotation: @denotations.map(&:to_h),
+        config: config
+      }.compact
+    end
+
+    private
+
+    def source_without_references
+      # Remove references from the source.
+
+      @source.gsub(ENTITY_TYPE_BLOCK_PATTERN) do |block|
+        block.start_with?("\n\n") ? "\n\n" : ""
+      end.strip
+    end
+
+    def get_obj_for(label)
+      @entity_type_collection.get(label) || label
+    end
+
+    def text_without_escape_backslash(text)
+      # Remove backslashes used to escape inline annotation format.
+      # For example, `\[Elon Musk][Person]` is treated as plain text
+      # rather than an annotation. This method removes the leading
+      # backslash and keeps the text as `[Elon Musk][Person]`.
+
+      text.gsub(ESCAPE_PATTERN, '')
+    end
+
+    def config
+      return nil unless @entity_type_collection.any?
+
+      { "entity types": @entity_type_collection.to_config }
+    end
+  end
+end

--- a/app/models/simple_inline_text_annotation/parser.rb
+++ b/app/models/simple_inline_text_annotation/parser.rb
@@ -37,9 +37,8 @@ class SimpleInlineTextAnnotation
 
     private
 
+    # Remove references from the source.
     def source_without_references
-      # Remove references from the source.
-
       @source.gsub(ENTITY_TYPE_BLOCK_PATTERN) do |block|
         block.start_with?("\n\n") ? "\n\n" : ""
       end.strip

--- a/app/models/simple_inline_text_annotation/parser.rb
+++ b/app/models/simple_inline_text_annotation/parser.rb
@@ -1,50 +1,52 @@
-class SimpleInlineTextAnnotation::Parser
-  # DENOTATION_PATTERN matches two consecutive pairs of square brackets.
-  # Example: [Annotated Text][Label]
-  DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/
+class SimpleInlineTextAnnotation
+  class Parser
+    # DENOTATION_PATTERN matches two consecutive pairs of square brackets.
+    # Example: [Annotated Text][Label]
+    DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/
 
-  def initialize(source)
-    @source = source.dup.freeze
-    @denotations = []
-    @entity_type_collection = SimpleInlineTextAnnotation::EntityTypeCollection.new(source)
-  end
-
-  def parse
-    full_text = source_without_references
-
-    while full_text =~ DENOTATION_PATTERN
-      match = Regexp.last_match
-      target_text = match[1]
-      label = match[2]
-
-      begin_pos = match.begin(0)
-      end_pos = begin_pos + target_text.length - 1 # -1 to adapt with zero-based indexing.
-      obj = get_obj_for(label)
-
-      @denotations << SimpleInlineTextAnnotation::Denotation.new(begin_pos, end_pos, obj)
-
-      # Replace the processed annotation with its text content
-      full_text[match.begin(0)...match.end(0)] = target_text
+    def initialize(source)
+      @source = source.dup.freeze
+      @denotations = []
+      @entity_type_collection = EntityTypeCollection.new(source)
     end
 
-    SimpleInlineTextAnnotation.new(
-      full_text,
-      @denotations,
-      @entity_type_collection
-    )
-  end
+    def parse
+      full_text = source_without_references
 
-  private
+      while full_text =~ DENOTATION_PATTERN
+        match = Regexp.last_match
+        target_text = match[1]
+        label = match[2]
 
-  def source_without_references
-    # Remove references from the source.
+        begin_pos = match.begin(0)
+        end_pos = begin_pos + target_text.length - 1 # -1 to adapt with zero-based indexing.
+        obj = get_obj_for(label)
 
-    @source.gsub(SimpleInlineTextAnnotation::ENTITY_TYPE_BLOCK_PATTERN) do |block|
-      block.start_with?("\n\n") ? "\n\n" : ""
-    end.strip
-  end
+        @denotations << Denotation.new(begin_pos, end_pos, obj)
 
-  def get_obj_for(label)
-    @entity_type_collection.get(label) || label
+        # Replace the processed annotation with its text content
+        full_text[match.begin(0)...match.end(0)] = target_text
+      end
+
+      SimpleInlineTextAnnotation.new(
+        full_text,
+        @denotations,
+        @entity_type_collection
+      )
+    end
+
+    private
+
+    def source_without_references
+      # Remove references from the source.
+
+      @source.gsub(ENTITY_TYPE_BLOCK_PATTERN) do |block|
+        block.start_with?("\n\n") ? "\n\n" : ""
+      end.strip
+    end
+
+    def get_obj_for(label)
+      @entity_type_collection.get(label) || label
+    end
   end
 end

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
+  describe '#parse' do
+    context 'when source has annotation structure' do
+      let(:source) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotation":[
+            {"span":{"begin": 0, "end": 8}, "obj":"Person"},
+            {"span":{"begin": 29, "end": 40}, "obj":"Organization"},
+          ]
+      }.to_json }
+
+      it 'parse as denotation' do
+        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        expect(output.to_json).to eq(expected_format)
+      end
+    end
+
+    context 'when surce has reference structure' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotation":[
+            {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
+            {"span":{"begin": 29, "end": 40}, "obj":"https://example.com/Organization"},
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" },
+            { "id": "https://example.com/Organization", "label": "Organization" }
+          ]
+        }
+      }.to_json }
+
+      it 'parse as entity types and apply id to denotation obj' do
+        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        expect(output.to_json).to eq(expected_format)
+      end
+    end
+
+    context 'when source has metacharacter escape' do
+      let(:source) { '\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
+      let(:expected_format) { {
+        "text": "[Elon Musk][Person] is a member of the PayPal Mafia.",
+        "denotation":[
+            {"span":{"begin": 40, "end": 51}, "obj":"Organization"}
+          ]
+      }.to_json }
+
+      it 'is not parsed as annotation' do
+        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        expect(output.to_json).to eq(expected_format)
+      end
+    end
+
+    context 'when reference definitions do not have a blank line above' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Person]: https://example.com/Person
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
+        "denotation":[
+            {"span":{"begin": 0, "end": 8}, "obj":"Person"}
+          ]
+      }.to_json }
+
+      it 'does not use as references' do
+        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        expect(output.to_json).to eq(expected_format)
+      end
+    end
+
+    context 'when reference definitions have a blank line above' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: https://example.com/Person
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotation":[
+            {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"}
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" }
+          ]
+        }
+      }.to_json }
+
+      it 'use definitions as references' do
+        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        expect(output.to_json).to eq(expected_format)
+      end
+    end
+
+    context 'when text is written below the reference definition' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: https://example.com/Person
+          hello
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.\n\nhello",
+        "denotation":[
+            {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"}
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" }
+          ]
+        }
+      }.to_json }
+
+      it 'parse as expected format' do
+        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        expect(output.to_json).to eq(expected_format)
+      end
+    end
+  end
+end

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -176,5 +176,26 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         is_expected.to eq(expected_format)
       end
     end
+
+    context 'when consecutive newlines in source' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+
+          Elon Musk is a member of the PayPal Mafia.
+          MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
+        "denotation":[
+            {"span":{"begin": 0, "end": 8}, "obj":"Person"},
+          ]
+      }.to_json }
+
+      it 'is parsed as single newline' do
+        is_expected.to eq(expected_format)
+      end
+    end
   end
 end

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'parse as denotation' do
-        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        output = SimpleInlineTextAnnotation.parse(source)
         expect(output.to_json).to eq(expected_format)
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'parse as entity types and apply id to denotation obj' do
-        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        output = SimpleInlineTextAnnotation.parse(source)
         expect(output.to_json).to eq(expected_format)
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'is not parsed as annotation' do
-        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        output = SimpleInlineTextAnnotation.parse(source)
         expect(output.to_json).to eq(expected_format)
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'does not use as references' do
-        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        output = SimpleInlineTextAnnotation.parse(source)
         expect(output.to_json).to eq(expected_format)
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'use definitions as references' do
-        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        output = SimpleInlineTextAnnotation.parse(source)
         expect(output.to_json).to eq(expected_format)
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'parse as expected format' do
-        output = SimpleInlineTextAnnotation::Parser.new(source).parse
+        output = SimpleInlineTextAnnotation.parse(source)
         expect(output.to_json).to eq(expected_format)
       end
     end

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
   describe '#parse' do
-    subject { SimpleInlineTextAnnotation.parse(source).to_json }
+    subject { SimpleInlineTextAnnotation.parse(source) }
 
     context 'when source has annotation structure' do
       let(:source) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
@@ -12,7 +12,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
             {"span":{"begin": 0, "end": 8}, "obj":"Person"},
             {"span":{"begin": 29, "end": 40}, "obj":"Organization"},
           ]
-      }.to_json }
+      } }
 
       it 'parse as denotation' do
         is_expected.to eq(expected_format)
@@ -40,7 +40,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
             { "id": "https://example.com/Organization", "label": "Organization" }
           ]
         }
-      }.to_json }
+      } }
 
       it 'parse as entity types and apply id to denotation obj' do
         is_expected.to eq(expected_format)
@@ -54,7 +54,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         "denotation":[
             {"span":{"begin": 40, "end": 51}, "obj":"Organization"}
           ]
-      }.to_json }
+      } }
 
       it 'is not parsed as annotation' do
         is_expected.to eq(expected_format)
@@ -73,7 +73,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         "denotation":[
             {"span":{"begin": 0, "end": 8}, "obj":"Person"}
           ]
-      }.to_json }
+      } }
 
       it 'does not use as references' do
         is_expected.to eq(expected_format)
@@ -98,7 +98,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
             { "id": "https://example.com/Person", "label": "Person" }
           ]
         }
-      }.to_json }
+      } }
 
       it 'use definitions as references' do
         is_expected.to eq(expected_format)
@@ -124,7 +124,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
             { "id": "https://example.com/Person", "label": "Person" }
           ]
         }
-      }.to_json }
+      } }
 
       it 'parse as expected format' do
         is_expected.to eq(expected_format)
@@ -150,7 +150,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
             { "id": "https://example.com/Person", "label": "Person" }
           ]
         }
-      }.to_json }
+      } }
 
       it 'use first defined id in priority' do
         is_expected.to eq(expected_format)
@@ -170,7 +170,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         "denotation":[
             {"span":{"begin": 0, "end": 8}, "obj":"Person"},
           ],
-      }.to_json }
+      } }
 
       it 'is do not create config' do
         is_expected.to eq(expected_format)
@@ -191,7 +191,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         "denotation":[
             {"span":{"begin": 0, "end": 8}, "obj":"Person"},
           ]
-      }.to_json }
+      } }
 
       it 'is parsed as single newline' do
         is_expected.to eq(expected_format)

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -130,5 +130,31 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         is_expected.to eq(expected_format)
       end
     end
+
+    context 'when reference id is duplicated' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: https://example.com/Person
+          [Person]: https://example.com/Organization
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotation":[
+            {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" }
+          ]
+        }
+      }.to_json }
+
+      it 'use first defined id in priority' do
+        is_expected.to eq(expected_format)
+      end
+    end
   end
 end

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
   describe '#parse' do
+    subject { SimpleInlineTextAnnotation.parse(source).to_json }
+
     context 'when source has annotation structure' do
       let(:source) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
       let(:expected_format) { {
@@ -13,8 +15,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'parse as denotation' do
-        output = SimpleInlineTextAnnotation.parse(source)
-        expect(output.to_json).to eq(expected_format)
+        is_expected.to eq(expected_format)
       end
     end
 
@@ -42,8 +43,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'parse as entity types and apply id to denotation obj' do
-        output = SimpleInlineTextAnnotation.parse(source)
-        expect(output.to_json).to eq(expected_format)
+        is_expected.to eq(expected_format)
       end
     end
 
@@ -57,8 +57,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'is not parsed as annotation' do
-        output = SimpleInlineTextAnnotation.parse(source)
-        expect(output.to_json).to eq(expected_format)
+        is_expected.to eq(expected_format)
       end
     end
 
@@ -77,8 +76,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'does not use as references' do
-        output = SimpleInlineTextAnnotation.parse(source)
-        expect(output.to_json).to eq(expected_format)
+        is_expected.to eq(expected_format)
       end
     end
 
@@ -103,8 +101,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'use definitions as references' do
-        output = SimpleInlineTextAnnotation.parse(source)
-        expect(output.to_json).to eq(expected_format)
+        is_expected.to eq(expected_format)
       end
     end
 
@@ -130,8 +127,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       }.to_json }
 
       it 'parse as expected format' do
-        output = SimpleInlineTextAnnotation.parse(source)
-        expect(output.to_json).to eq(expected_format)
+        is_expected.to eq(expected_format)
       end
     end
   end

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -156,5 +156,25 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         is_expected.to eq(expected_format)
       end
     end
+
+    context 'when reference label and id is same' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: Person
+          MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotation":[
+            {"span":{"begin": 0, "end": 8}, "obj":"Person"},
+          ],
+      }.to_json }
+
+      it 'is do not create config' do
+        is_expected.to eq(expected_format)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
SimpleInlineTextAnnotationをJSONに変換する機能を作成しました。

## レビュー修正内容
- モジュール名AnnotationParserをSimpleInlineTextAnnotationに変更, インデントのズレ修正
  - https://github.com/pubannotation/pubannotation/commit/3aacc780c781f928440c89c0b6a8456b0e8da17a
- to_configのコメント追加
  - https://github.com/pubannotation/pubannotation/commit/c7d4bb5519bacf4cb568a0b83211cf21f46411e8
- entity_typeメソッドのコメントをメソッド定義の上に移動
  - https://github.com/pubannotation/pubannotation/commit/3d55632d2aa74349f703cf86ba62e5bcca2b14ff
- AnnotationParserをクラスにして、アノテーションを表現するデータ構造に変更
  - https://github.com/pubannotation/pubannotation/commit/390381a66a9efae0761c27483ffd27065746fd7b

## テスト
```
rspec spec/models/simple_inline_text_annotation
......

Finished in 0.02318 seconds (files took 0.84952 seconds to load)
6 examples, 0 failures
```