### PR TITLE
Fix label definition structure parse rule

### DIFF
--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -5,7 +5,7 @@ class SimpleInlineTextAnnotation
   #
   # [Label1]: URL1
   # [Label2]: URL2
-  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:^\[[^\]]+\]:\s+\S+\n(?!\s))+)/
+  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:^\[[^\]]+\]:\s+\S+(?:\s+(?:"[^"]*"|'[^']*'))?\s*(?:\n|$))+)/
 
   # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
   # Example: \[This is a part of][original text]

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -1,11 +1,14 @@
 class SimpleInlineTextAnnotation
+  # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
+  # Similar to Markdown, this also matches when there is text enclosed in "" or '' after the URL.
+  # Match example:
+  #  - [Label]: URL
+  #  - [Label]: URL "text"
+  ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*$/
+
   # ENTITY_TYPE_BLOCK_PATTERN matches a block of the entity type definitions.
   # Requires a blank line above the block definition.
-  # Example:
-  #
-  # [Label1]: URL1
-  # [Label2]: URL2
-  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:^\[[^\]]+\]:\s+\S+(?:\s+(?:"[^"]*"|'[^']*'))?\s*(?:\n|$))+)/
+  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:#{ENTITY_TYPE_PATTERN}*(?:\n|$))+)/
 
   # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
   # Example: \[This is a part of][original text]

--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -5,7 +5,7 @@ class SimpleInlineTextAnnotation
   #
   # [Label1]: URL1
   # [Label2]: URL2
-  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:^\[[^\]]+\]:\s+.+\n)+)/
+  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:^\[[^\]]+\]:\s+\S+\n(?!\s))+)/
 
   # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
   # Example: \[This is a part of][original text]

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -2,7 +2,7 @@ class SimpleInlineTextAnnotation
   class EntityTypeCollection
     # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
     # Example: [Label]: URL
-    ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(.*)/
+    ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(\S+)$/
 
     def initialize(source)
       @source = source

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -1,8 +1,11 @@
 class SimpleInlineTextAnnotation
   class EntityTypeCollection
     # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
-    # Example: [Label]: URL
-    ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(\S+)$/
+    # Similar to Markdown, this also matches when there is text enclosed in "" or '' after the URL.
+    # Match example:
+    #  - [Label]: URL
+    #  - [Label]: URL "text"
+    ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*$/
 
     def initialize(source)
       @source = source

--- a/app/models/simple_inline_text_annotation/entity_type_collection.rb
+++ b/app/models/simple_inline_text_annotation/entity_type_collection.rb
@@ -1,12 +1,5 @@
 class SimpleInlineTextAnnotation
   class EntityTypeCollection
-    # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
-    # Similar to Markdown, this also matches when there is text enclosed in "" or '' after the URL.
-    # Match example:
-    #  - [Label]: URL
-    #  - [Label]: URL "text"
-    ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*$/
-
     def initialize(source)
       @source = source
     end

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -106,6 +106,34 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     end
 
     context 'when reference contains additional text after url' do
+      context 'when text is enclosed with quotation' do
+        let(:source) do
+          <<~MD2
+            [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+            [Person]: https://example.com/Person "text"
+            [Organization]: https://example.com/Organization 'text'
+          MD2
+        end
+        let(:expected_format) { {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotation":[
+              {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
+              {"span":{"begin": 29, "end": 40}, "obj":"https://example.com/Organization"},
+            ],
+          "config": {
+            "entity types": [
+              { "id": "https://example.com/Person", "label": "Person" },
+              { "id": "https://example.com/Organization", "label": "Organization" }
+            ]
+          }
+        } }
+
+        it 'parsed as reference link' do
+          is_expected.to eq(expected_format)
+        end
+      end
+
       context 'when text is not enclosed with quotation' do
         let(:source) do
           <<~MD2

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -105,6 +105,28 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
     end
 
+    context 'when reference contains additional text after url' do
+      context 'when text is not enclosed with quotation' do
+        let(:source) do
+          <<~MD2
+            [Elon Musk][Person] is a member of the PayPal Mafia.
+
+            [Person]: https://example.com/Person text
+          MD2
+        end
+        let(:expected_format) { {
+          "text": "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
+          "denotation":[
+              {"span":{"begin": 0, "end": 8}, "obj":"Person"}
+            ]
+        } }
+
+        it 'does not parse as reference link' do
+          is_expected.to eq(expected_format)
+        end
+      end
+    end
+
     context 'when text is written below the reference definition' do
       let(:source) do
         <<~MD2


### PR DESCRIPTION
## 概要
inline2json機能の参照リンクの解釈の仕方を修正しました。

## 作業内容
- 参照リンク定義のURLの後に空白+文字がある場合にmarkdown同様に参照リンクと解釈しないように変更
- 空白+"xxx"または空白+'xxx'のように文字がクォーテーションで囲まれている場合は参照リンクとして解釈
- 上記2つの使用に対するテストケースを追加

## テスト
```
rspec spec/models/simple_inline_text_annotation
...........

Finished in 0.02546 seconds (files took 1.03 seconds to load)
11 examples, 0 failures
```