### PR TITLE
Add inline2json API

### DIFF
--- a/app/controllers/conversions/inline2json_controller.rb
+++ b/app/controllers/conversions/inline2json_controller.rb
@@ -1,0 +1,12 @@
+class Conversions::Inline2jsonController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :create
+
+  def create
+    source = request.body.read
+    result = SimpleInlineTextAnnotation.parse(source)
+
+    render json: result, status: :ok
+  rescue => e
+    render json: { error: e.message }, status: :internal_server_error
+  end
+end

--- a/app/controllers/conversions/inline2json_controller.rb
+++ b/app/controllers/conversions/inline2json_controller.rb
@@ -1,7 +1,14 @@
 class Conversions::Inline2jsonController < ApplicationController
   skip_before_action :verify_authenticity_token, only: :create
 
+  MAX_PAYLOAD_SIZE = 10.megabytes
+
   def create
+    if request.content_length >= MAX_PAYLOAD_SIZE
+      render json: { error: 'Payload too large. The size should be less than 10 MB.' }, status: :payload_too_large
+      return
+    end
+
     source = request.body.read
     result = SimpleInlineTextAnnotation.parse(source)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -318,4 +318,9 @@ Pubann::Application.routes.draw do
 		resource :update_paragraph_references_job, only: [:show, :create, :destroy]
 		resource :update_sentence_references_job, only: [:show, :create, :destroy]
 	end
+
+	# SimpleInlineTextAnnotation conversion API
+	namespace :conversions do
+		resources :inline2json, only: :create
+	end
 end

--- a/spec/requests/conversions/inline2json_spec.rb
+++ b/spec/requests/conversions/inline2json_spec.rb
@@ -17,5 +17,15 @@ RSpec.describe "Spans", type: :request do
         expect(response).to have_http_status(200)
       end
     end
+
+    context 'when payload size exceeds the limit' do
+      let(:large_payload) { "A" * 10.megabytes }
+
+      it 'returns 413 payload too large' do
+        post "/conversions/inline2json", params: large_payload
+
+        expect(response).to have_http_status(:payload_too_large)
+      end
+    end
   end
 end

--- a/spec/requests/conversions/inline2json_spec.rb
+++ b/spec/requests/conversions/inline2json_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "Spans", type: :request do
+  describe "POST /conversions/inline2json" do
+    context 'when requested with body' do
+      it 'returns 200 ok' do
+        post "/conversions/inline2json", params: '[Elon Musk][Person] is a member of the PayPal Mafia.'
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when requested without body' do
+      it 'returns 200 ok' do
+        post "/conversions/inline2json"
+
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
inline2json APIを作成しました。

## 作業内容
- controllers/conversions/inline2json_controller.rbを作成
- inline2json_controller#createにinline2json変換APIを実装
- ルーティング追加
- リクエストテスト追加

## テスト結果
```
bundle exec rspec
....................................................................................................................................................................................................................
.........................................

Finished in 16.73 seconds (files took 0.62228 seconds to load)
253 examples, 0 failures
```
