### PR TITLE
Fix inline2json API problems

### DIFF
--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -28,7 +28,7 @@ class SimpleInlineTextAnnotation
   def to_h
     {
       text: format_text(@text),
-      denotation: @denotations.map(&:to_h),
+      denotations: @denotations.map(&:to_h),
       config: config
     }.compact
   end

--- a/app/models/simple_inline_text_annotation/parser.rb
+++ b/app/models/simple_inline_text_annotation/parser.rb
@@ -19,7 +19,7 @@ class SimpleInlineTextAnnotation
         label = match[2]
 
         begin_pos = match.begin(0)
-        end_pos = begin_pos + target_text.length - 1 # -1 to adapt with zero-based indexing.
+        end_pos = begin_pos + target_text.length
         obj = get_obj_for(label)
 
         @denotations << Denotation.new(begin_pos, end_pos, obj)

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:source) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 0, "end": 8}, "obj":"Person"},
             {"span":{"begin": 29, "end": 40}, "obj":"Organization"},
           ]
@@ -30,7 +30,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
             {"span":{"begin": 29, "end": 40}, "obj":"https://example.com/Organization"},
           ],
@@ -51,7 +51,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:source) { '\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
       let(:expected_format) { {
         "text": "[Elon Musk][Person] is a member of the PayPal Mafia.",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 40, "end": 51}, "obj":"Organization"}
           ]
       } }
@@ -70,7 +70,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 0, "end": 8}, "obj":"Person"}
           ]
       } }
@@ -90,7 +90,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"}
           ],
         "config": {
@@ -117,7 +117,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         end
         let(:expected_format) { {
           "text": "Elon Musk is a member of the PayPal Mafia.",
-          "denotation":[
+          "denotations":[
               {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
               {"span":{"begin": 29, "end": 40}, "obj":"https://example.com/Organization"},
             ],
@@ -144,7 +144,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         end
         let(:expected_format) { {
           "text": "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
-          "denotation":[
+          "denotations":[
               {"span":{"begin": 0, "end": 8}, "obj":"Person"}
             ]
         } }
@@ -166,7 +166,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.\n\nhello",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"}
           ],
         "config": {
@@ -192,7 +192,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
           ],
         "config": {
@@ -217,7 +217,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 0, "end": 8}, "obj":"Person"},
           ],
       } }
@@ -238,7 +238,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
-        "denotation":[
+        "denotations":[
             {"span":{"begin": 0, "end": 8}, "obj":"Person"},
           ]
       } }

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
         "denotations":[
-            {"span":{"begin": 0, "end": 8}, "obj":"Person"},
-            {"span":{"begin": 29, "end": 40}, "obj":"Organization"},
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+            {"span":{"begin": 29, "end": 41}, "obj":"Organization"},
           ]
       } }
 
@@ -31,8 +31,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
         "denotations":[
-            {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
-            {"span":{"begin": 29, "end": 40}, "obj":"https://example.com/Organization"},
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
           ],
         "config": {
           "entity types": [
@@ -52,7 +52,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "[Elon Musk][Person] is a member of the PayPal Mafia.",
         "denotations":[
-            {"span":{"begin": 40, "end": 51}, "obj":"Organization"}
+            {"span":{"begin": 40, "end": 52}, "obj":"Organization"}
           ]
       } }
 
@@ -71,7 +71,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
         "denotations":[
-            {"span":{"begin": 0, "end": 8}, "obj":"Person"}
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"}
           ]
       } }
 
@@ -91,7 +91,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
         "denotations":[
-            {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"}
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"}
           ],
         "config": {
           "entity types": [
@@ -118,8 +118,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         let(:expected_format) { {
           "text": "Elon Musk is a member of the PayPal Mafia.",
           "denotations":[
-              {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
-              {"span":{"begin": 29, "end": 40}, "obj":"https://example.com/Organization"},
+              {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+              {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
             ],
           "config": {
             "entity types": [
@@ -145,7 +145,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         let(:expected_format) { {
           "text": "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
           "denotations":[
-              {"span":{"begin": 0, "end": 8}, "obj":"Person"}
+              {"span":{"begin": 0, "end": 9}, "obj":"Person"}
             ]
         } }
 
@@ -167,7 +167,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.\n\nhello",
         "denotations":[
-            {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"}
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"}
           ],
         "config": {
           "entity types": [
@@ -193,7 +193,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
         "denotations":[
-            {"span":{"begin": 0, "end": 8}, "obj":"https://example.com/Person"},
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
           ],
         "config": {
           "entity types": [
@@ -218,7 +218,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
         "denotations":[
-            {"span":{"begin": 0, "end": 8}, "obj":"Person"},
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
           ],
       } }
 
@@ -239,7 +239,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:expected_format) { {
         "text": "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
         "denotations":[
-            {"span":{"begin": 0, "end": 8}, "obj":"Person"},
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
           ]
       } }
 


### PR DESCRIPTION
## 概要
inline2json APIの不具合を修正しました。

## 修正内容
- 変換結果のdenotationキー名をdenotationsに修正
  - denotationsの"s"が抜けており、TextAEで読み込めていなかったため
- denotationのend_posの計算を修正
  - 一文字足りない状態でdenotationが表示されていたため

## 動作確認
TextAEで期待する形での表示を確認
|<img width="621" alt="image" src="https://github.com/user-attachments/assets/f0eba46f-9128-4a29-9c8b-6672ee17623d" />|
|:-|

## テスト
```
bundle exec rspec
................................................................................................................................................................................................................................................................

Finished in 16.22 seconds (files took 0.62266 seconds to load)
256 examples, 0 failures
```

