### PR TITLE
Implement InlineTextAnnotation generator

### DIFF
--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -25,6 +25,10 @@ class SimpleInlineTextAnnotation
     result.to_h
   end
 
+  def self.generate(source)
+    SimpleInlineTextAnnotation::Generator.new(source).generate
+  end
+
   def to_h
     {
       text: format_text(@text),

--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -20,6 +20,14 @@ class SimpleInlineTextAnnotation
       other.begin_pos <= @begin_pos && @end_pos <= other.end_pos
     end
 
+    def position_negative?
+      @begin_pos < 0 || @end_pos < 0
+    end
+
+    def position_invalid?
+      @begin_pos > @end_pos
+    end
+
     def boundary_crossing?(other)
       starts_inside_other = @begin_pos > other.begin_pos && @begin_pos < other.end_pos
       ends_inside_other = @end_pos > other.begin_pos && @end_pos < other.end_pos

--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -1,8 +1,18 @@
 class SimpleInlineTextAnnotation
   class Denotation
+    attr_reader :span, :obj
+
     def initialize(begin_pos, end_pos, obj)
       @span = { begin: begin_pos, end: end_pos }
       @obj = obj
+    end
+
+    def begin_pos
+      @span[:begin]
+    end
+
+    def end_pos
+      @span[:end]
     end
 
     def to_h

--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -18,5 +18,16 @@ class SimpleInlineTextAnnotation
     def to_h
       { span: @span, obj: @obj }
     end
+
+    def nested_within?(other)
+      other.begin_pos <= begin_pos && end_pos <= other.end_pos
+    end
+
+    def boundary_crossing?(other)
+      starts_inside_other = begin_pos > other.begin_pos && begin_pos < other.end_pos
+      ends_inside_other = end_pos > other.begin_pos && end_pos < other.end_pos
+
+      starts_inside_other || ends_inside_other
+    end
   end
 end

--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -1,31 +1,28 @@
 class SimpleInlineTextAnnotation
   class Denotation
-    attr_reader :span, :obj
+    attr_reader :begin_pos, :end_pos, :obj
 
     def initialize(begin_pos, end_pos, obj)
-      @span = { begin: begin_pos, end: end_pos }
+      @begin_pos = begin_pos
+      @end_pos = end_pos
       @obj = obj
     end
 
-    def begin_pos
-      @span[:begin]
-    end
-
-    def end_pos
-      @span[:end]
+    def span
+      { begin: @begin_pos, end: @end_pos }
     end
 
     def to_h
-      { span: @span, obj: @obj }
+      { span: span, obj: @obj }
     end
 
     def nested_within?(other)
-      other.begin_pos <= begin_pos && end_pos <= other.end_pos
+      other.begin_pos <= @begin_pos && @end_pos <= other.end_pos
     end
 
     def boundary_crossing?(other)
-      starts_inside_other = begin_pos > other.begin_pos && begin_pos < other.end_pos
-      ends_inside_other = end_pos > other.begin_pos && end_pos < other.end_pos
+      starts_inside_other = @begin_pos > other.begin_pos && @begin_pos < other.end_pos
+      ends_inside_other = @end_pos > other.begin_pos && @end_pos < other.end_pos
 
       starts_inside_other || ends_inside_other
     end

--- a/app/models/simple_inline_text_annotation/denotation_standardizer.rb
+++ b/app/models/simple_inline_text_annotation/denotation_standardizer.rb
@@ -1,0 +1,33 @@
+class SimpleInlineTextAnnotation
+  module DenotationStandardizer
+    # Standardize denotations by removing duplicates, nested, and boundary-crossing spans.
+    def standardize(denotations)
+      result = remove_duplicates_from(denotations)
+      result = remove_nests_from(result)
+      remove_boundary_crosses_from(result)
+    end
+
+    private
+
+    def remove_duplicates_from(denotations)
+      denotations.uniq { |denotation| denotation.span }
+    end
+
+    def remove_nests_from(denotations)
+      sorted_denotations = denotations.sort_by { |d| [d.begin_pos, -d.end_pos] }
+      result = []
+
+      sorted_denotations.each do |denotation|
+        result << denotation unless result.any? { |outer| denotation.nested_within?(outer) }
+      end
+
+      result
+    end
+
+    def remove_boundary_crosses_from(denotations)
+      denotations.reject do |denotation|
+        denotations.any? { |existing| denotation.boundary_crossing?(existing) }
+      end
+    end
+  end
+end

--- a/app/models/simple_inline_text_annotation/denotation_standardizer.rb
+++ b/app/models/simple_inline_text_annotation/denotation_standardizer.rb
@@ -3,6 +3,8 @@ class SimpleInlineTextAnnotation
     # Standardize denotations by removing duplicates, nested, and boundary-crossing spans.
     def standardize(denotations)
       result = remove_duplicates_from(denotations)
+      result = remove_negative_positions_from(result)
+      result = remove_invalid_positions_from(result)
       result = remove_nests_from(result)
       remove_boundary_crosses_from(result)
     end
@@ -11,6 +13,18 @@ class SimpleInlineTextAnnotation
 
     def remove_duplicates_from(denotations)
       denotations.uniq { |denotation| denotation.span }
+    end
+
+    def remove_negative_positions_from(denotations)
+      denotations.reject do |denotation|
+        denotation.begin_pos < 0 || denotation.end_pos < 0
+      end
+    end
+
+    def remove_invalid_positions_from(denotations)
+      denotations.reject do |denotation|
+        denotation.end_pos < denotation.begin_pos
+      end
     end
 
     def remove_nests_from(denotations)

--- a/app/models/simple_inline_text_annotation/denotation_validator.rb
+++ b/app/models/simple_inline_text_annotation/denotation_validator.rb
@@ -1,7 +1,6 @@
 class SimpleInlineTextAnnotation
-  module DenotationStandardizer
-    # Standardize denotations by removing duplicates, nested, and boundary-crossing spans.
-    def standardize(denotations)
+  module DenotationValidator
+    def validate(denotations)
       result = remove_duplicates_from(denotations)
       result = remove_negative_positions_from(result)
       result = remove_invalid_positions_from(result)

--- a/app/models/simple_inline_text_annotation/denotation_validator.rb
+++ b/app/models/simple_inline_text_annotation/denotation_validator.rb
@@ -27,6 +27,7 @@ class SimpleInlineTextAnnotation
     end
 
     def remove_nests_from(denotations)
+      # Sort by begin_pos in ascending order. If begin_pos is the same, sort by end_pos in descending order.
       sorted_denotations = denotations.sort_by { |d| [d.begin_pos, -d.end_pos] }
       result = []
 

--- a/app/models/simple_inline_text_annotation/denotation_validator.rb
+++ b/app/models/simple_inline_text_annotation/denotation_validator.rb
@@ -15,15 +15,11 @@ class SimpleInlineTextAnnotation
     end
 
     def remove_negative_positions_from(denotations)
-      denotations.reject do |denotation|
-        denotation.begin_pos < 0 || denotation.end_pos < 0
-      end
+      denotations.reject { |denotation| denotation.position_negative? }
     end
 
     def remove_invalid_positions_from(denotations)
-      denotations.reject do |denotation|
-        denotation.end_pos < denotation.begin_pos
-      end
+      denotations.reject { |denotation| denotation.position_invalid? }
     end
 
     def remove_nests_from(denotations)

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -3,7 +3,7 @@ class SimpleInlineTextAnnotation
     include DenotationValidator
 
     def initialize(source)
-      @source = source.freeze
+      @source = source.dup.freeze
       @denotations = build_denotations(source[:denotations] || [])
     end
 

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -5,15 +5,15 @@ class SimpleInlineTextAnnotation
     def initialize(source)
       @source = source.dup.freeze
       @denotations = build_denotations(source[:denotations] || [])
+      @config = @source[:config]
     end
 
     def generate
       text = @source[:text]
       denotations = validate(@denotations)
-      config = @source[:config]
 
-      annotated_text = annotate_text(text, denotations, config)
-      label_definitions = build_label_definitions(config)
+      annotated_text = annotate_text(text, denotations)
+      label_definitions = build_label_definitions
 
       [annotated_text, label_definitions].compact.join("\n\n")
     end
@@ -24,12 +24,12 @@ class SimpleInlineTextAnnotation
       denotations.map { |d| Denotation.new(d[:span][:begin], d[:span][:end], d[:obj])}
     end
 
-    def annotate_text(text, denotations, config)
+    def annotate_text(text, denotations)
       # Annotate text from the end to ensure position calculation.
       denotations.sort_by(&:begin_pos).reverse_each do |denotation|
         begin_pos = denotation.begin_pos
         end_pos = denotation.end_pos
-        obj = get_obj(denotation.obj, config)
+        obj = get_obj(denotation.obj)
 
         annotated_text = "[#{text[begin_pos...end_pos]}][#{obj}]"
         text = text[0...begin_pos] + annotated_text + text[end_pos..]
@@ -38,17 +38,21 @@ class SimpleInlineTextAnnotation
       text
     end
 
-    def get_obj(obj, config)
-      return obj unless config && config[:"entity types"]
+    def entity_types
+      @config ? @config[:"entity types"] : nil
+    end
 
-      entity = config[:"entity types"].find { |entity_type| entity_type[:id] == obj }
+    def get_obj(obj)
+      return obj unless entity_types
+
+      entity = entity_types.find { |entity_type| entity_type[:id] == obj }
       entity ? entity[:label] : obj
     end
 
-    def build_label_definitions(config)
-      return nil unless config && config[:"entity types"]
+    def build_label_definitions
+      return nil unless entity_types
 
-      config[:"entity types"].map do |entity|
+      entity_types.map do |entity|
         "[#{entity[:label]}]: #{entity[:id]}"
       end.join("\n")
     end

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -3,7 +3,7 @@ class SimpleInlineTextAnnotation
     include DenotationValidator
 
     def initialize(source)
-      @source = source
+      @source = source.freeze
       @denotations = build_denotations(source[:denotations] || [])
     end
 
@@ -26,7 +26,7 @@ class SimpleInlineTextAnnotation
 
     def annotate_text(text, denotations, config)
       # Annotate text from the end to ensure position calculation.
-      denotations.reverse_each do |denotation|
+      denotations.sort_by(&:begin_pos).reverse_each do |denotation|
         begin_pos = denotation.begin_pos
         end_pos = denotation.end_pos
         obj = get_obj(denotation.obj, config)

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -1,0 +1,48 @@
+class SimpleInlineTextAnnotation
+  class Generator
+    def initialize(source)
+      @source = source
+    end
+
+    def generate
+      text = @source[:text]
+      denotations = standardize_denotations(@source[:denotations] || [])
+      config = @source[:config]
+
+      annotated_text = annotate_text(text, denotations)
+      label_definitions = build_label_definitions(config)
+
+      [annotated_text, label_definitions].compact.join("\n\n")
+    end
+
+    private
+
+    # Only use the first denotation if the span range is the same.
+    # Also sort denotations in descending for later annotation process.
+    def standardize_denotations(denotations)
+      denotations.uniq { |denotation| denotation[:span] }
+                 .sort_by { |denotation| -denotation[:span][:begin] }
+    end
+
+    def annotate_text(text, denotations)
+      denotations.each do |denotation|
+        begin_pos = denotation[:span][:begin]
+        end_pos = denotation[:span][:end]
+        obj = denotation[:obj]
+
+        annotated_text = "[#{text[begin_pos...end_pos]}][#{obj}]"
+        text = text[0...begin_pos] + annotated_text + text[end_pos..]
+      end
+
+      text
+    end
+
+    def build_label_definitions(config)
+      return nil unless config && config[:"entity types"]
+
+      config[:"entity types"].map do |entity|
+        "[#{entity[:label]}]: #{entity[:id]}"
+      end.join("\n")
+    end
+  end
+end

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -1,6 +1,6 @@
 class SimpleInlineTextAnnotation
   class Generator
-    include DenotationStandardizer
+    include DenotationValidator
 
     def initialize(source)
       @source = source
@@ -9,7 +9,7 @@ class SimpleInlineTextAnnotation
 
     def generate
       text = @source[:text]
-      denotations = standardize(@denotations)
+      denotations = validate(@denotations)
       config = @source[:config]
 
       annotated_text = annotate_text(text, denotations, config)

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -2,11 +2,12 @@ class SimpleInlineTextAnnotation
   class Generator
     def initialize(source)
       @source = source
+      @denotations = build_denotations(source[:denotations] || [])
     end
 
     def generate
       text = @source[:text]
-      denotations = standardize_denotations(@source[:denotations] || [])
+      denotations = standardize_denotations(@denotations)
       config = @source[:config]
 
       annotated_text = annotate_text(text, denotations, config)
@@ -17,14 +18,27 @@ class SimpleInlineTextAnnotation
 
     private
 
-    # Standardize denotations by removing duplicates and nested spans.
-    def standardize_denotations(denotations)
-      sorted_denotations = denotations.uniq { |denotation| denotation[:span] }
-                                      .sort_by { |denotation| denotation[:span][:begin] }
+    def build_denotations(denotations)
+      denotations.map { |d| Denotation.new(d[:span][:begin], d[:span][:end], d[:obj])}
+    end
 
+    # Standardize denotations by removing duplicates, nested, and boundary-crossing spans.
+    def standardize_denotations(denotations)
+      result = remove_duplicates_from(denotations)
+      result = remove_nesting_from(result)
+      remove_boundary_crossing_from(result)
+    end
+
+    def remove_duplicates_from(denotations)
+      denotations.uniq { |denotation| denotation.span }
+    end
+
+    def remove_nesting_from(denotations)
+      sorted_denotations = denotations.sort_by { |d| [d.begin_pos, -d.end_pos] }
       result = []
+
       sorted_denotations.each do |denotation|
-        unless result.any? { |r| r[:span][:begin] <= denotation[:span][:begin] && r[:span][:end] >= denotation[:span][:end] }
+        unless result.any? { |r| r.begin_pos <= denotation.begin_pos && r.end_pos >= denotation.end_pos }
           result << denotation
         end
       end
@@ -32,12 +46,30 @@ class SimpleInlineTextAnnotation
       result
     end
 
+    def remove_boundary_crossing_from(denotations)
+      denotations.reject do |denotation|
+        denotations.any? do |existing|
+          boundary_crossing?(denotation, existing)
+        end
+      end
+    end
+
+    def boundary_crossing?(denotation, existing)
+      is_start_of_denotation_span_between_existing_span =
+        existing.begin_pos < denotation.begin_pos && denotation.begin_pos < existing.end_pos && existing.end_pos < denotation.end_pos
+
+      is_end_of_denotation_span_between_existing_span =
+        denotation.begin_pos < existing.begin_pos && existing.begin_pos < denotation.end_pos && denotation.end_pos < existing.end_pos
+
+        is_start_of_denotation_span_between_existing_span || is_end_of_denotation_span_between_existing_span
+    end
+
     def annotate_text(text, denotations, config)
       # Annotate text from the end to ensure position calculation.
       denotations.reverse_each do |denotation|
-        begin_pos = denotation[:span][:begin]
-        end_pos = denotation[:span][:end]
-        obj = get_obj(denotation[:obj], config)
+        begin_pos = denotation.begin_pos
+        end_pos = denotation.end_pos
+        obj = get_obj(denotation.obj, config)
 
         annotated_text = "[#{text[begin_pos...end_pos]}][#{obj}]"
         text = text[0...begin_pos] + annotated_text + text[end_pos..]

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -9,7 +9,7 @@ class SimpleInlineTextAnnotation
       denotations = standardize_denotations(@source[:denotations] || [])
       config = @source[:config]
 
-      annotated_text = annotate_text(text, denotations)
+      annotated_text = annotate_text(text, denotations, config)
       label_definitions = build_label_definitions(config)
 
       [annotated_text, label_definitions].compact.join("\n\n")
@@ -24,17 +24,24 @@ class SimpleInlineTextAnnotation
                  .sort_by { |denotation| -denotation[:span][:begin] }
     end
 
-    def annotate_text(text, denotations)
+    def annotate_text(text, denotations, config)
       denotations.each do |denotation|
         begin_pos = denotation[:span][:begin]
         end_pos = denotation[:span][:end]
-        obj = denotation[:obj]
+        obj = get_obj(denotation[:obj], config)
 
         annotated_text = "[#{text[begin_pos...end_pos]}][#{obj}]"
         text = text[0...begin_pos] + annotated_text + text[end_pos..]
       end
 
       text
+    end
+
+    def get_obj(obj, config)
+      return obj unless config && config[:"entity types"]
+
+      entity = config[:"entity types"].find { |entity_type| entity_type[:id] == obj }
+      entity ? entity[:label] : obj
     end
 
     def build_label_definitions(config)

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -34,18 +34,50 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
-    context 'when source has nested spans' do
-      let(:source) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-          {"span":{"begin": 0, "end": 9}, "obj":"Person"},
-          {"span":{"begin": 2, "end": 6}, "obj":"Organization"},
-        ]
-        } }
-      let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+    context 'when source has nested span within another span' do
+      context 'when both begin and end are inside' do
+        let(:source) { {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+            {"span":{"begin": 2, "end": 6}, "obj":"Organization"},
+          ]
+          } }
+        let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
 
-      it 'should use only outer denotation' do
-        is_expected.to eq(expected_format)
+        it 'should use only outer denotation' do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context 'when begin is inside' do
+        let(:source) { {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations":[
+            {"span":{"begin": 0, "end": 4}, "obj":"First name"},
+            {"span":{"begin": 0, "end": 9}, "obj":"Full name"},
+          ]
+          } }
+        let(:expected_format) { '[Elon Musk][Full name] is a member of the PayPal Mafia.' }
+
+        it 'should use only outer denotation' do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context 'when end is inside' do
+        let(:source) { {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations":[
+            {"span":{"begin": 6, "end": 9}, "obj":"Last name"},
+            {"span":{"begin": 0, "end": 9}, "obj":"Full name"},
+          ]
+          } }
+        let(:expected_format) { '[Elon Musk][Full name] is a member of the PayPal Mafia.' }
+
+        it 'should use only outer denotation' do
+          is_expected.to eq(expected_format)
+        end
       end
     end
 

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
+  describe '#generate' do
+    subject { SimpleInlineTextAnnotation.generate(source) }
+
+    context 'when source has denotations' do
+      let(:source) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+          {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+          {"span":{"begin": 29, "end": 41}, "obj":"Organization"},
+        ]
+        } }
+      let(:expected_format) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
+
+      it 'generate annotation structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
+  end
+end

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -18,5 +18,33 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         is_expected.to eq(expected_format)
       end
     end
+
+    context 'when source has config' do
+      let(:source) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" },
+            { "id": "https://example.com/Organization", "label": "Organization" }
+          ]
+        }
+      } }
+      let(:expected_format) do
+        <<~MD2.chomp
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD2
+      end
+
+      it 'generate label definition structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
   end
 end

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -19,6 +19,36 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
+    context 'when source has same span denotations' do
+      let(:source) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+          {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+          {"span":{"begin": 0, "end": 9}, "obj":"Organization"},
+        ]
+        } }
+      let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+
+      it 'should use first denotation' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when source has nested spans' do
+      let(:source) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+          {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+          {"span":{"begin": 2, "end": 6}, "obj":"Organization"},
+        ]
+        } }
+      let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+
+      it 'should use only outer denotation' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
     context 'when source has config' do
       let(:source) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         } }
       let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
 
-      it 'should use only outer denotation' do
+      it 'should be both ignored' do
         is_expected.to eq(expected_format)
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         } }
       let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
 
-      it 'generate annotation structure' do
+      it 'should be ignored' do
         is_expected.to eq(expected_format)
       end
     end
@@ -147,7 +147,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         } }
       let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
 
-      it 'generate annotation structure' do
+      it 'should be ignored' do
         is_expected.to eq(expected_format)
       end
     end

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -19,6 +19,34 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
+    context 'when source has config' do
+      let(:source) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" },
+            { "id": "https://example.com/Organization", "label": "Organization" }
+          ]
+        }
+      } }
+      let(:expected_format) do
+        <<~MD2.chomp
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD2
+      end
+
+      it 'generate label definition structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
     context 'when source has same span denotations' do
       let(:source) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",
@@ -92,34 +120,6 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
 
       it 'should use only outer denotation' do
-        is_expected.to eq(expected_format)
-      end
-    end
-
-    context 'when source has config' do
-      let(:source) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
-            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
-          ],
-        "config": {
-          "entity types": [
-            { "id": "https://example.com/Person", "label": "Person" },
-            { "id": "https://example.com/Organization", "label": "Organization" }
-          ]
-        }
-      } }
-      let(:expected_format) do
-        <<~MD2.chomp
-          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
-
-          [Person]: https://example.com/Person
-          [Organization]: https://example.com/Organization
-        MD2
-      end
-
-      it 'generate label definition structure' do
         is_expected.to eq(expected_format)
       end
     end

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
+    context 'when source has boundary-crossing denotations' do
+      let(:source) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+          {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+          {"span":{"begin": 8, "end": 11}, "obj":"Organization"},
+        ]
+        } }
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'should use only outer denotation' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
     context 'when source has config' do
       let(:source) { {
         "text": "Elon Musk is a member of the PayPal Mafia.",

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -123,5 +123,33 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         is_expected.to eq(expected_format)
       end
     end
+
+    context 'when denotations span is negative' do
+      let(:source) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+          {"span":{"begin": -1, "end": 9}, "obj":"Person"},
+        ]
+        } }
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'generate annotation structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when denotations span is invalid' do
+      let(:source) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+          {"span":{"begin": 4, "end": 0}, "obj":"Person"},
+        ]
+        } }
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'generate annotation structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
JSONをSimpleInlineTextAnnotationFormatに変換する機能を作成しました。

## 行ったこと
- 変換機能の追加
- テストの追加

### 詳細な仕様について
細かい仕様については、相談時に決定した方針またはTextAEと合わせる形で実装しました。
- 同じspanを持つdenotationがある場合
  - JSONで先に定義されているdenotationのみ使用
- 入れ子でdenotationが定義されている場合
  - 最も外側のdenotationのみ使用
- 2つのdenotationのbegin/endのどちらかが同じで、どちらかが違う場合
  - 入れ子と同じように範囲の広いdenotationのみ使用
- 2つのdenotationが境界交差している場合
  - TextAEでは両方表示されなくなるため、合わせて両方非表示に
- begin/endに負の値がある場合
  - TextAEでは表示されなくなるため、合わせて非表示に
- endがbeginより前の値の場合
  - TextAEでは表示されなくなるため、合わせて非表示に

## テスト結果
```
bundle exec rspec
.........................................................................................................................................................................................................................................................................

Finished in 16.33 seconds (files took 0.83894 seconds to load)
265 examples, 0 failures
```