### PR TITLE
Add content type validation to inline2json API

### DIFF
--- a/app/controllers/conversions/inline2json_controller.rb
+++ b/app/controllers/conversions/inline2json_controller.rb
@@ -10,7 +10,7 @@ class Conversions::Inline2jsonController < ApplicationController
     end
 
     if request.content_length >= MAX_PAYLOAD_SIZE
-      render json: { error: 'Payload too large. The size should be less than 10 MB.' }, status: :payload_too_large
+      render plain: "ERROR: Payload too large. The size should be less than 10 MB.", status: :payload_too_large
       return
     end
 
@@ -19,6 +19,6 @@ class Conversions::Inline2jsonController < ApplicationController
 
     render json: result, status: :ok
   rescue => e
-    render json: { error: e.message }, status: :internal_server_error
+    render plain: "ERROR: #{e.message}", status: :internal_server_error
   end
 end

--- a/app/controllers/conversions/inline2json_controller.rb
+++ b/app/controllers/conversions/inline2json_controller.rb
@@ -4,6 +4,11 @@ class Conversions::Inline2jsonController < ApplicationController
   MAX_PAYLOAD_SIZE = 10.megabytes
 
   def create
+    unless request.content_type == 'text/plain' || request.content_type == 'text/markdown'
+      render plain: "ERROR: Invalid content type. Please set text/plain or text/markdown to Content-Type.", status: :unsupported_media_type
+      return
+    end
+
     if request.content_length >= MAX_PAYLOAD_SIZE
       render json: { error: 'Payload too large. The size should be less than 10 MB.' }, status: :payload_too_large
       return

--- a/spec/requests/conversions/inline2json_spec.rb
+++ b/spec/requests/conversions/inline2json_spec.rb
@@ -29,5 +29,13 @@ RSpec.describe "Spans", type: :request do
         expect(response).to have_http_status(:payload_too_large)
       end
     end
+
+    context 'when no content-type specified' do
+      it 'returns 415 unsupported_media_type' do
+        post "/conversions/inline2json"
+
+        expect(response).to have_http_status(415)
+      end
+    end
   end
 end

--- a/spec/requests/conversions/inline2json_spec.rb
+++ b/spec/requests/conversions/inline2json_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "Spans", type: :request do
   describe "POST /conversions/inline2json" do
     context 'when requested with body' do
       it 'returns 200 ok' do
-        post "/conversions/inline2json", params: '[Elon Musk][Person] is a member of the PayPal Mafia.'
+        post "/conversions/inline2json", params: '[Elon Musk][Person] is a member of the PayPal Mafia.',
+                                         headers: { 'Content-Type' => 'text/markdown' }
 
         expect(response).to have_http_status(200)
       end
@@ -12,7 +13,7 @@ RSpec.describe "Spans", type: :request do
 
     context 'when requested without body' do
       it 'returns 200 ok' do
-        post "/conversions/inline2json"
+        post "/conversions/inline2json", headers: { 'Content-Type' => 'text/markdown' }
 
         expect(response).to have_http_status(200)
       end
@@ -22,7 +23,8 @@ RSpec.describe "Spans", type: :request do
       let(:large_payload) { "A" * 10.megabytes }
 
       it 'returns 413 payload too large' do
-        post "/conversions/inline2json", params: large_payload
+        post "/conversions/inline2json", params: large_payload,
+                                         headers: { 'Content-Type' => 'text/markdown' }
 
         expect(response).to have_http_status(:payload_too_large)
       end


### PR DESCRIPTION
## 概要
inline2json APIに、Content-Typeのバリデーションを追加しました。

## 作業内容
- バリデーションの追加
- エラーレスポンスをplain textで返すように修正
- テストケースの追加
- 既存テストが失敗するようになったため修正

## 動作確認
Content-Typeを指定しなかった場合
```
curl -X POST http://localhost:3000/conversions/inline2json \
-d "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization]."
ERROR: Invalid content type. Please set text/plain or text/markdown to Content-Type.
```

## テスト結果
```
bundle exec rspec
..........................................................................................................................................................................................................................................................................

Finished in 17.71 seconds (files took 0.71144 seconds to load)
266 examples, 0 failures
```