### PR TITLE
Implement json2line API

### DIFF
--- a/app/controllers/conversions/json2inline_controller.rb
+++ b/app/controllers/conversions/json2inline_controller.rb
@@ -13,6 +13,8 @@ class Conversions::Json2inlineController < ApplicationController
     render plain: result, status: :ok
   rescue JSON::ParserError => e
     render plain: "ERROR: Invalid JSON. Details: #{e.message}", status: :bad_request
+  rescue SimpleInlineTextAnnotation::GeneratorError => e
+    render plain: "ERROR: #{e.message}", status: :bad_request
   rescue => e
     render plain: "ERROR: #{e.message}", status: :internal_server_error
   end

--- a/app/controllers/conversions/json2inline_controller.rb
+++ b/app/controllers/conversions/json2inline_controller.rb
@@ -1,0 +1,19 @@
+class Conversions::Json2inlineController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :create
+
+  def create
+    unless request.content_type == 'application/json'
+      render plain: "ERROR: Invalid content type. Please set application/json to Content-Type.", status: :unsupported_media_type
+      return
+    end
+
+    source = JSON.parse(request.body.read)
+    result = SimpleInlineTextAnnotation.generate(source)
+
+    render plain: result, status: :ok
+  rescue JSON::ParserError => e
+    render plain: "ERROR: Invalid JSON. Details: #{e.message}", status: :bad_request
+  rescue => e
+    render plain: "ERROR: #{e.message}", status: :internal_server_error
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -322,6 +322,7 @@ Pubann::Application.routes.draw do
 	# SimpleInlineTextAnnotation conversion API
 	namespace :conversions do
 		resources :inline2json, only: :create
+		resources :json2inline, only: :create
 	end
 
 	# TextAE open API

--- a/spec/requests/conversions/json2inline_spec.rb
+++ b/spec/requests/conversions/json2inline_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "Json2inline", type: :request do
+  describe "POST /conversions/json2inline" do
+    let(:json_annotation) { '{ "text": "sample text" }' }
+
+    context 'when requested with valid JSON' do
+      it 'returns 200 ok' do
+        post "/conversions/json2inline", params: json_annotation,
+                                         headers: { 'Content-Type' => 'application/json' }
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when requested with invalid JSON' do
+      it 'returns 400 bad request' do
+        post "/conversions/json2inline", params: '{ invalid_json }',
+                                         headers: { 'Content-Type' => 'application/json' }
+
+        expect(response).to have_http_status(400)
+      end
+    end
+
+    context 'when requested without content-type' do
+      it 'returns 415 unsupported_media_type' do
+        post "/conversions/json2inline", params: json_annotation
+
+        expect(response).to have_http_status(415)
+      end
+    end
+
+    context 'when requested with invalid content-type' do
+      it 'returns 415 unsupported_media_type' do
+        post "/conversions/json2inline", params: json_annotation,
+                                         headers: { 'Content-Type' => 'text/plain' }
+
+        expect(response).to have_http_status(415)
+      end
+    end
+  end
+end

--- a/spec/requests/conversions/json2inline_spec.rb
+++ b/spec/requests/conversions/json2inline_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe "Json2inline", type: :request do
       end
     end
 
+    context 'when requested without text key in JSON' do
+      it 'returns 400 bad request' do
+        post "/conversions/json2inline", params: '{ "denotations": [] }',
+                                         headers: { 'Content-Type' => 'application/json' }
+
+        expect(response).to have_http_status(400)
+      end
+    end
+
     context 'when requested without content-type' do
       it 'returns 415 unsupported_media_type' do
         post "/conversions/json2inline", params: json_annotation


### PR DESCRIPTION
## 概要
JSON2Inline APIを作成しました。

このPRのコミットは以下からです。
[Add json2inline API](https://github.com/pubannotation/pubannotation/pull/167/commits/dd999d76c899b083e4c2ee054864d4dcda177385)

## 作業内容
- controllers/conversions/json2inline_controller.rbを作成
- json2inline_controller#createにjson2inline変換APIを実装
- ルーティング追加
- リクエストテスト追加

## テスト内容と結果
### テスト内容
- 有効なJSONを渡したとき、200ステータスが返ること
- 無効なJSONを渡したとき、400エラーが返ること
- JSONにtextキーがないとき、400エラーが返ること
- Content-Typeを指定しなかったとき、415エラーが返ること
- application/json以外のContent-Typeを指定したとき、415エラーが返ること

### 結果
```
➜  pubannotation git:(feature/add_json2inline_api) bundle exec rspec
.........................................................................................................................................................................................................................................................................................

Finished in 18.61 seconds (files took 0.70775 seconds to load)
281 examples, 0 failures
```
