### PR TITLE
Fix JSON2Inline Generator problems

### DIFF
--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -28,6 +28,10 @@ class SimpleInlineTextAnnotation
       @begin_pos > @end_pos
     end
 
+    def out_of_bounds?(text_length)
+      @begin_pos >= text_length || @end_pos > text_length
+    end
+
     def boundary_crossing?(other)
       starts_inside_other = @begin_pos > other.begin_pos && @begin_pos < other.end_pos
       ends_inside_other = @end_pos > other.begin_pos && @end_pos < other.end_pos

--- a/app/models/simple_inline_text_annotation/denotation_validator.rb
+++ b/app/models/simple_inline_text_annotation/denotation_validator.rb
@@ -1,9 +1,10 @@
 class SimpleInlineTextAnnotation
   module DenotationValidator
-    def validate(denotations)
+    def validate(denotations, text_length)
       result = remove_duplicates_from(denotations)
       result = remove_negative_positions_from(result)
       result = remove_invalid_positions_from(result)
+      result = remove_out_of_bound_positions_from(result, text_length)
       result = remove_nests_from(result)
       remove_boundary_crosses_from(result)
     end
@@ -20,6 +21,10 @@ class SimpleInlineTextAnnotation
 
     def remove_invalid_positions_from(denotations)
       denotations.reject { |denotation| denotation.position_invalid? }
+    end
+
+    def remove_out_of_bound_positions_from(denotations, text_length)
+      denotations.reject { |denotation| denotation.out_of_bounds?(text_length) }
     end
 
     def remove_nests_from(denotations)

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -4,12 +4,12 @@ class SimpleInlineTextAnnotation
 
     def initialize(source)
       @source = source.dup.freeze
-      @denotations = build_denotations(source[:denotations] || [])
-      @config = @source[:config]
+      @denotations = build_denotations(source["denotations"] || [])
+      @config = @source["config"]
     end
 
     def generate
-      text = @source[:text]
+      text = @source["text"]
       denotations = validate(@denotations)
 
       annotated_text = annotate_text(text, denotations)
@@ -21,7 +21,7 @@ class SimpleInlineTextAnnotation
     private
 
     def build_denotations(denotations)
-      denotations.map { |d| Denotation.new(d[:span][:begin], d[:span][:end], d[:obj])}
+      denotations.map { |d| Denotation.new(d["span"]["begin"], d["span"]["end"], d["obj"]) }
     end
 
     def annotate_text(text, denotations)
@@ -39,21 +39,21 @@ class SimpleInlineTextAnnotation
     end
 
     def entity_types
-      @config ? @config[:"entity types"] : nil
+      @config ? @config["entity types"] : nil
     end
 
     def get_obj(obj)
       return obj unless entity_types
 
-      entity = entity_types.find { |entity_type| entity_type[:id] == obj }
-      entity ? entity[:label] : obj
+      entity = entity_types.find { |entity_type| entity_type["id"] == obj }
+      entity ? entity["label"] : obj
     end
 
     def build_label_definitions
       return nil unless entity_types
 
       entity_types.map do |entity|
-        "[#{entity[:label]}]: #{entity[:id]}"
+        "[#{entity["label"]}]: #{entity["id"]}"
       end.join("\n")
     end
   end

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -11,7 +11,7 @@ class SimpleInlineTextAnnotation
     def generate
       text = @source["text"]
       raise SimpleInlineTextAnnotation::GeneratorError, 'The "text" key is missing.' if text.nil?
-      denotations = validate(@denotations)
+      denotations = validate(@denotations, text.length)
 
       annotated_text = annotate_text(text, denotations)
       label_definitions = build_label_definitions

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -10,6 +10,7 @@ class SimpleInlineTextAnnotation
 
     def generate
       text = @source["text"]
+      raise SimpleInlineTextAnnotation::GeneratorError, 'The "text" key is missing.' if text.nil?
       denotations = validate(@denotations)
 
       annotated_text = annotate_text(text, denotations)

--- a/app/models/simple_inline_text_annotation/generator_error.rb
+++ b/app/models/simple_inline_text_annotation/generator_error.rb
@@ -1,0 +1,7 @@
+class SimpleInlineTextAnnotation
+  class GeneratorError < StandardError
+    def initialize(msg = nil)
+      super(msg)
+    end
+  end
+end

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -151,5 +151,17 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         is_expected.to eq(expected_format)
       end
     end
+
+    context 'when source text key is missing' do
+      let(:source) { {
+        "denotations" => [
+          {"span" => {"begin" => 4, "end" => 0}, "obj" => "Person"},
+        ]
+      } }
+
+      it 'raises GeneratorError' do
+        expect { subject }.to raise_error(SimpleInlineTextAnnotation::GeneratorError, 'The "text" key is missing.')
+      end
+    end
   end
 end

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -152,6 +152,20 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
+    context 'when denotation is out of bound with text length' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 100, "end" => 200}, "obj" => "Person"},
+        ]
+      } }
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'should be ignored' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
     context 'when source text key is missing' do
       let(:source) { {
         "denotations" => [

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
     context 'when source has denotations' do
       let(:source) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-          {"span":{"begin": 0, "end": 9}, "obj":"Person"},
-          {"span":{"begin": 29, "end": 41}, "obj":"Organization"},
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
+          {"span" => {"begin" => 29, "end" => 41}, "obj" => "Organization"},
         ]
-        } }
+      } }
       let(:expected_format) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
 
       it 'generate annotation structure' do
@@ -21,15 +21,15 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
     context 'when source has config' do
       let(:source) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
-            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+            {"span" => {"begin" => 0, "end" => 9}, "obj" => "https://example.com/Person"},
+            {"span" => {"begin" => 29, "end" => 41}, "obj" => "https://example.com/Organization"},
           ],
-        "config": {
-          "entity types": [
-            { "id": "https://example.com/Person", "label": "Person" },
-            { "id": "https://example.com/Organization", "label": "Organization" }
+        "config" => {
+          "entity types" => [
+            { "id" => "https://example.com/Person", "label" => "Person" },
+            { "id" => "https://example.com/Organization", "label" => "Organization" }
           ]
         }
       } }
@@ -49,12 +49,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
     context 'when source has same span denotations' do
       let(:source) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-          {"span":{"begin": 0, "end": 9}, "obj":"Person"},
-          {"span":{"begin": 0, "end": 9}, "obj":"Organization"},
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Organization"},
         ]
-        } }
+      } }
       let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
 
       it 'should use first denotation' do
@@ -65,12 +65,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
     context 'when source has nested span within another span' do
       context 'when both begin and end are inside' do
         let(:source) { {
-          "text": "Elon Musk is a member of the PayPal Mafia.",
-          "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
-            {"span":{"begin": 2, "end": 6}, "obj":"Organization"},
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
+            {"span" => {"begin" => 2, "end" => 6}, "obj" => "Organization"},
           ]
-          } }
+        } }
         let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
 
         it 'should use only outer denotation' do
@@ -80,12 +80,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
       context 'when begin is inside' do
         let(:source) { {
-          "text": "Elon Musk is a member of the PayPal Mafia.",
-          "denotations":[
-            {"span":{"begin": 0, "end": 4}, "obj":"First name"},
-            {"span":{"begin": 0, "end": 9}, "obj":"Full name"},
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            {"span" => {"begin" => 0, "end" => 4}, "obj" => "First name"},
+            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Full name"},
           ]
-          } }
+        } }
         let(:expected_format) { '[Elon Musk][Full name] is a member of the PayPal Mafia.' }
 
         it 'should use only outer denotation' do
@@ -95,12 +95,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
       context 'when end is inside' do
         let(:source) { {
-          "text": "Elon Musk is a member of the PayPal Mafia.",
-          "denotations":[
-            {"span":{"begin": 6, "end": 9}, "obj":"Last name"},
-            {"span":{"begin": 0, "end": 9}, "obj":"Full name"},
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            {"span" => {"begin" => 6, "end" => 9}, "obj" => "Last name"},
+            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Full name"},
           ]
-          } }
+        } }
         let(:expected_format) { '[Elon Musk][Full name] is a member of the PayPal Mafia.' }
 
         it 'should use only outer denotation' do
@@ -111,12 +111,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
     context 'when source has boundary-crossing denotations' do
       let(:source) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-          {"span":{"begin": 0, "end": 9}, "obj":"Person"},
-          {"span":{"begin": 8, "end": 11}, "obj":"Organization"},
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
+          {"span" => {"begin" => 8, "end" => 11}, "obj" => "Organization"},
         ]
-        } }
+      } }
       let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
 
       it 'should be both ignored' do
@@ -126,11 +126,11 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
     context 'when denotations span is negative' do
       let(:source) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-          {"span":{"begin": -1, "end": 9}, "obj":"Person"},
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => -1, "end" => 9}, "obj" => "Person"},
         ]
-        } }
+      } }
       let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
 
       it 'should be ignored' do
@@ -140,11 +140,11 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
     context 'when denotations span is invalid' do
       let(:source) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-          {"span":{"begin": 4, "end": 0}, "obj":"Person"},
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 4, "end" => 0}, "obj" => "Person"},
         ]
-        } }
+      } }
       let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
 
       it 'should be ignored' do


### PR DESCRIPTION
## 概要
JSON2Inline機能に実装漏れと不具合があったため修正を行いました。

## 作業内容
- sourceからのキー取得をJSONに合わせてシンボルから文字列に変更
- sourceにtextキーがない場合に例外を出すように変更
- テキストの長さ以上のspanを持つdenotationを無視するように変更

### sourceからのキー取得をJSONに合わせてシンボルから文字列に変更
SimpleInlineTextAnnotation.generate()に渡す値はJSONをパースしたHashを想定しています。

JSONをパースするとHashのkeyは文字列になりますが、SimpleInlineTextAnnotation::Generatorではシンボルを期待していてエラーが起こるようになっていました。(テストコードでは表記ミスによってシンボル形になっていました)

この問題を修正するために、Generatorクラス内では文字列でのキー取得に変更し、テストコードも修正しました。
[Generatorクラスの修正](https://github.com/pubannotation/pubannotation/commit/16f914971f1ca8b1338684782295c0434830bcd2)
[テストコードの修正](https://github.com/pubannotation/pubannotation/commit/63f4c8101690aa4feb82cc61d94a1c0ceec9651c)

### sourceにtextキーがない場合に例外を出すように変更
sourceにtextキーがないと空文字が返るようになっていました。
これを例外を出すように修正しました。
https://github.com/pubannotation/pubannotation/commit/e77eed4cd053aa7b255f5260dab1f50348147d6b

### テキストの長さ以上のspanを持つdenotationを無視するように変更
テキストの長さ以上のspanを持つdenotationがあると、TypeErrorが発生してしまっていました。
これに対応するために、DenotationValidatorにバリデーションを追加しました。
https://github.com/pubannotation/pubannotation/commit/2d75738efe932110d845d7572b586fff2f18c791

## テスト結果
```
bundle exec rspec
............................................................................................................................................................................................................................................................................

Finished in 15.63 seconds (files took 0.5657 seconds to load)
268 examples, 0 failures
```