### PR TITLE
Fix label definition problem on JSON2Inline function

### DIFF
--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -15,7 +15,6 @@ class SimpleInlineTextAnnotation
 
       annotated_text = annotate_text(text, denotations)
       label_definitions = build_label_definitions
-
       [annotated_text, label_definitions].compact.join("\n\n")
     end
 
@@ -39,21 +38,23 @@ class SimpleInlineTextAnnotation
       text
     end
 
-    def entity_types
-      @config ? @config["entity types"] : nil
+    def labeled_entity_types
+      return [] unless @config
+
+      @config["entity types"].select { |entity_type| entity_type.key?("label") }
     end
 
     def get_obj(obj)
-      return obj unless entity_types
+      return obj if labeled_entity_types.empty?
 
-      entity = entity_types.find { |entity_type| entity_type["id"] == obj }
+      entity = labeled_entity_types.find { |entity_type| entity_type["id"] == obj }
       entity ? entity["label"] : obj
     end
 
     def build_label_definitions
-      return nil unless entity_types
+      return nil if labeled_entity_types.empty?
 
-      entity_types.map do |entity|
+      labeled_entity_types.map do |entity|
         "[#{entity["label"]}]: #{entity["id"]}"
       end.join("\n")
     end

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -40,7 +40,7 @@ class SimpleInlineTextAnnotation
     end
 
     def labeled_entity_types
-      return [] unless @config
+      return [] if @config.nil? || @config["entity types"].nil?
 
       @config["entity types"].select { |entity_type| entity_type.key?("label") }
     end

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -40,20 +40,20 @@ class SimpleInlineTextAnnotation
     end
 
     def labeled_entity_types
-      return [] if @config.nil? || @config["entity types"].nil?
+      return nil unless @config
 
-      @config["entity types"].select { |entity_type| entity_type.key?("label") }
+      @config["entity types"]&.select { |entity_type| entity_type.key?("label") }
     end
 
     def get_obj(obj)
-      return obj if labeled_entity_types.empty?
+      return obj unless labeled_entity_types
 
       entity = labeled_entity_types.find { |entity_type| entity_type["id"] == obj }
       entity ? entity["label"] : obj
     end
 
     def build_label_definitions
-      return nil if labeled_entity_types.empty?
+      return nil if labeled_entity_types.blank?
 
       labeled_entity_types.map do |entity|
         "[#{entity["label"]}]: #{entity["id"]}"

--- a/app/models/simple_inline_text_annotation/generator.rb
+++ b/app/models/simple_inline_text_annotation/generator.rb
@@ -15,6 +15,7 @@ class SimpleInlineTextAnnotation
 
       annotated_text = annotate_text(text, denotations)
       label_definitions = build_label_definitions
+
       [annotated_text, label_definitions].compact.join("\n\n")
     end
 

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -47,6 +47,26 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
+    context 'when entity type has present but label is missing' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"}
+        ],
+        "config" => {
+          "entity types" => [
+            {"id" => "Person"}
+          ]
+        }
+      }}
+
+      let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+
+      it 'should create only annotation structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
     context 'when source has same span denotations' do
       let(:source) { {
         "text" => "Elon Musk is a member of the PayPal Mafia.",


### PR DESCRIPTION
## 概要
JSON2Inline機能のlabel形成ロジックの不具合を修正しました。

## 修正内容
- entity typesにlabelがない場合はlabel definition structureを形成しないように変更

## 動作確認
次のJSONを用いて確認します。
```
{
  "text": "Elon Musk is a member of the PayPal Mafia.",
  "denotations": [
    {
      "span": {
        "begin": 0,
        "end": 9
      },
      "obj": "Person"
    }
  ],
  "config": {
    "entity types": [
      {
        "id": "Person"
      }
    ]
  }
}
```
### 修正前
修正前は空のアノテーションブラケットとlabel definition structureが形成されてしまっていました。
<img width="724" alt="image" src="https://github.com/user-attachments/assets/edd8ef52-fb9b-4ee6-930a-fae066c66ba4" />


### 修正後
修正後は空のlabel definition structureが形成されずアノテーションが付くようになりました。

出力
```
[Elon Musk][Person] is a member of the PayPal Mafia.
```

## テスト結果
```
rspec spec/models/simple_inline_text_annotation/generator_spec.rb
............

Finished in 0.02664 seconds (files took 0.69953 seconds to load)
12 examples, 0 failures
```
