### PR TITLE
Fix to ignore whitespaces  before label definition on Inline2JSON parser

### DIFF
--- a/app/models/simple_inline_text_annotation.rb
+++ b/app/models/simple_inline_text_annotation.rb
@@ -4,11 +4,11 @@ class SimpleInlineTextAnnotation
   # Match example:
   #  - [Label]: URL
   #  - [Label]: URL "text"
-  ENTITY_TYPE_PATTERN = /^\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*$/
+  ENTITY_TYPE_PATTERN = /^\s*\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*$/
 
   # ENTITY_TYPE_BLOCK_PATTERN matches a block of the entity type definitions.
   # Requires a blank line above the block definition.
-  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n{2,})((?:#{ENTITY_TYPE_PATTERN}*(?:\n|$))+)/
+  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n\s*\n)((?:#{ENTITY_TYPE_PATTERN}(?:\n|$))+)/
 
   # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
   # Example: \[This is a part of][original text]

--- a/spec/models/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/models/simple_inline_text_annotation/parser_spec.rb
@@ -247,5 +247,34 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         is_expected.to eq(expected_format)
       end
     end
+
+    context 'when white spaces before reference definition' do
+      let(:source) do
+        # Using <<- to create white spaces
+        <<-MD2
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" },
+            { "id": "https://example.com/Organization", "label": "Organization" }
+          ]
+        }
+      } }
+
+      it 'parse as entity types with ignoring white spaces' do
+        is_expected.to eq(expected_format)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
Inline2JSON変換機能にて、label definition structureの前に空白があるとlabel definition structureとして解析されない問題を修正しました。

## 動作確認
RSpecでの確認に加えて、TextAEで以下のように読み込んだ場合に正しくパースできていることを確認しました。
HTML
```
    <div class="textae-editor" mode="edit">
        [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].

        [Person]: https://example.com/Person
        [Organization]: https://example.com/Organization
    </div>
```

|<img width="451" alt="image" src="https://github.com/user-attachments/assets/2ce95975-fc24-4c58-9365-2e1b5c7cbd19" />|
|:-|

|<img width="450" alt="image" src="https://github.com/user-attachments/assets/33ecdfc1-a29f-4918-b625-8ec4bd0043c5" />|
|:-|