### PR TITLE
Fix JSON2Inline problem

### DIFF
--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -20,8 +20,8 @@ class SimpleInlineTextAnnotation
       other.begin_pos <= @begin_pos && @end_pos <= other.end_pos
     end
 
-    def position_integer?
-      @begin_pos.is_a?(Integer) && @end_pos.is_a?(Integer)
+    def position_not_integer?
+      !(@begin_pos.is_a?(Integer) && @end_pos.is_a?(Integer))
     end
 
     def position_negative?

--- a/app/models/simple_inline_text_annotation/denotation.rb
+++ b/app/models/simple_inline_text_annotation/denotation.rb
@@ -20,6 +20,10 @@ class SimpleInlineTextAnnotation
       other.begin_pos <= @begin_pos && @end_pos <= other.end_pos
     end
 
+    def position_integer?
+      @begin_pos.is_a?(Integer) && @end_pos.is_a?(Integer)
+    end
+
     def position_negative?
       @begin_pos < 0 || @end_pos < 0
     end

--- a/app/models/simple_inline_text_annotation/denotation_validator.rb
+++ b/app/models/simple_inline_text_annotation/denotation_validator.rb
@@ -17,7 +17,7 @@ class SimpleInlineTextAnnotation
     end
 
     def remove_non_integer_positions_from(denotations)
-      denotations.select { |denotation| denotation.position_integer? }
+      denotations.reject { |denotation| denotation.position_not_integer? }
     end
 
     def remove_negative_positions_from(denotations)

--- a/app/models/simple_inline_text_annotation/denotation_validator.rb
+++ b/app/models/simple_inline_text_annotation/denotation_validator.rb
@@ -2,6 +2,7 @@ class SimpleInlineTextAnnotation
   module DenotationValidator
     def validate(denotations, text_length)
       result = remove_duplicates_from(denotations)
+      result = remove_non_integer_positions_from(result)
       result = remove_negative_positions_from(result)
       result = remove_invalid_positions_from(result)
       result = remove_out_of_bound_positions_from(result, text_length)
@@ -13,6 +14,10 @@ class SimpleInlineTextAnnotation
 
     def remove_duplicates_from(denotations)
       denotations.uniq { |denotation| denotation.span }
+    end
+
+    def remove_non_integer_positions_from(denotations)
+      denotations.select { |denotation| denotation.position_integer? }
     end
 
     def remove_negative_positions_from(denotations)

--- a/spec/models/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/models/simple_inline_text_annotation/generator_spec.rb
@@ -67,6 +67,22 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
+    context 'when span value is not integer' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0.1, "end" => 9.6}, "obj" => "Person"},
+          {"span" => {"begin" => "0", "end" => "9"}, "obj" => "Organization"}
+        ]
+      }}
+
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'should not parse as annotation' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
     context 'when source has same span denotations' do
       let(:source) { {
         "text" => "Elon Musk is a member of the PayPal Mafia.",


### PR DESCRIPTION
## 概要
JSON2Inline機能に、渡したアノテーションのspan begin/end値が整数以外の場合は無効にするバリデーションを追加しました。

## 作業内容
- DenotationValidatorに型のバリデーションを追加
- テストの追加

## 動作確認
### 少数または文字列のspanを持つdenotationが無効になる
```
curl -X POST http://localhost:3000/conversions/json2inline \
  -H "Content-Type: application/json" \
  -d '{
  "text": "Elon Musk is a member of the PayPal Mafia",
  "denotations":[
    {"span":{"begin": 0.4, "end": 9.6 }, "obj":"Person"},
    {"span":{"begin": "29", "end": "41" }, "obj":"Organization"}
  ]
}'
Elon Musk is a member of the PayPal Mafia
```

### テスト結果
```
bundle exec rspec
............................................................................................................................................................................................................................................................................................

Finished in 18 seconds (files took 0.89622 seconds to load)
284 examples, 0 failures
```