### PR TITLE
Fix term search logic to use AND instead of OR

### DIFF
--- a/app/models/concerns/term_search_concern.rb
+++ b/app/models/concerns/term_search_concern.rb
@@ -11,6 +11,8 @@ module TermSearchConcern
       if predicates.nil? || predicates&.include?('denotes')
         with_denotations = search_in_denotations(terms, user, project_names)
                              .select(:doc_id, 'docs.sourcedb', :'docs.sourceid')
+                             .group(:doc_id, 'docs.sourcedb', :'docs.sourceid')
+                             .having('COUNT(DISTINCT denotations.obj) = ?', terms.size)
 
         with_attributes.union(with_denotations)
       else
@@ -25,6 +27,8 @@ module TermSearchConcern
       if predicates&.include?('denotes')
         with_denotations = search_in_denotations(terms, user, project_names)
                              .select(:doc_id, :begin, :end, 'docs.sourcedb', :'docs.sourceid')
+                             .group(:doc_id, :begin, :end, 'docs.sourcedb', :'docs.sourceid')
+                             .having('COUNT(DISTINCT denotations.obj) = ?', terms.size)
 
         with_attributes.union(with_denotations)
       else


### PR DESCRIPTION
## 概要
TermSearch機能でtermsでの検索ロジックをORからANDに変更しました。

## 修正前
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/acd41146-ff55-40d0-91d1-dfc6cdacd676" />|
|:-|

## 修正後
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/04c77917-e159-4afd-bb03-d0ec633b3951" />|
|:-|