### PR TITLE
Change SimpleInlineTextAnnotationFormat MIME-type and file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ curl --globoff -X POST https://pubannotation.org/textae \
 ##### SimpleInlineTextAnnotationFormat
 ```
 curl -X POST https://pubannotation.org/textae \
-  -H "Content-Type: text/markdown" \
+  -H "Content-Type: text/plain" \
   -d "[Elon Musk][Person] is a member of the PayPal Mafia.
 
       [Person]: https://example.com/Person"
@@ -207,6 +207,6 @@ curl example:
 Use `--data-binary` option instead of `-d`
 ```
 curl -X POST http://pubannotation.org/textae \
-  -H "Content-Type: text/markdown" \
-  --data-binary @sample.md
+  -H "Content-Type: text/plain" \
+  --data-binary @sample.txt
 ```

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ curl --globoff -X POST https://pubannotation.org/textae \
   -H "Content-Type: application/json" \
   -d '{
          "text": "Elon Musk is a member of the PayPal Mafia.",
-         "denotation":[
-           {"span":{"begin": 0, "end": 8}, "obj":"Person"},
+         "denotations":[
+           {"span":{"begin": 0, "end": 9}, "obj":"Person"}
          ]
        }'
 ```

--- a/app/controllers/conversions/inline2json_controller.rb
+++ b/app/controllers/conversions/inline2json_controller.rb
@@ -4,8 +4,8 @@ class Conversions::Inline2jsonController < ApplicationController
   MAX_PAYLOAD_SIZE = 10.megabytes
 
   def create
-    unless request.content_type == 'text/plain' || request.content_type == 'text/markdown'
-      render plain: "ERROR: Invalid content type. Please set text/plain or text/markdown to Content-Type.", status: :unsupported_media_type
+    unless request.content_type == 'text/plain'
+      render plain: "ERROR: Invalid content type. Please set text/plain to Content-Type.", status: :unsupported_media_type
       return
     end
 

--- a/app/controllers/textae_annotations_controller.rb
+++ b/app/controllers/textae_annotations_controller.rb
@@ -2,7 +2,7 @@ class TextaeAnnotationsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: %i[create show]
 
   def create
-    unless ['text/markdown', 'application/json'].include?(request.content_type)
+    unless ['text/plain', 'application/json'].include?(request.content_type)
       render json: { error: 'Invalid content-type. Please set the correct content-type according to the request.' }, status: :unsupported_media_type
       return
     end
@@ -36,7 +36,7 @@ class TextaeAnnotationsController < ApplicationController
 
   def parse(body)
     case request.content_type
-    when 'text/markdown'
+    when 'text/plain'
       annotation = SimpleInlineTextAnnotation.parse(body)
       JSON.pretty_generate(annotation)
     when 'application/json'

--- a/spec/requests/conversions/inline2json_spec.rb
+++ b/spec/requests/conversions/inline2json_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Spans", type: :request do
     context 'when requested with body' do
       it 'returns 200 ok' do
         post "/conversions/inline2json", params: '[Elon Musk][Person] is a member of the PayPal Mafia.',
-                                         headers: { 'Content-Type' => 'text/markdown' }
+                                         headers: { 'Content-Type' => 'text/plain' }
 
         expect(response).to have_http_status(200)
       end
@@ -13,7 +13,7 @@ RSpec.describe "Spans", type: :request do
 
     context 'when requested without body' do
       it 'returns 200 ok' do
-        post "/conversions/inline2json", headers: { 'Content-Type' => 'text/markdown' }
+        post "/conversions/inline2json", headers: { 'Content-Type' => 'text/plain' }
 
         expect(response).to have_http_status(200)
       end
@@ -24,7 +24,7 @@ RSpec.describe "Spans", type: :request do
 
       it 'returns 413 payload too large' do
         post "/conversions/inline2json", params: large_payload,
-                                         headers: { 'Content-Type' => 'text/markdown' }
+                                         headers: { 'Content-Type' => 'text/plain' }
 
         expect(response).to have_http_status(:payload_too_large)
       end

--- a/spec/requests/textae_annotations_spec.rb
+++ b/spec/requests/textae_annotations_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe "TextaeAnnotations", type: :request do
     context 'when requested with inline annotation' do
       it 'should be created' do
         count = TextaeAnnotation.count
-        post "/textae", params: inline_annotation, headers: { 'Content-Type' => 'text/markdown' }
+        post "/textae", params: inline_annotation, headers: { 'Content-Type' => 'text/plain' }
 
         expect(TextaeAnnotation.count).to eq(count + 1)
       end
 
       it 'should be saved as JSON' do
-        post "/textae", params: inline_annotation, headers: { 'Content-Type' => 'text/markdown' }
+        post "/textae", params: inline_annotation, headers: { 'Content-Type' => 'text/plain' }
         created_annotation = TextaeAnnotation.last.annotation
 
         expect { JSON.parse(created_annotation) }.not_to raise_error


### PR DESCRIPTION
## 概要
SimpleInlineTextAnnotationFormatとして期待するMIME-typeと拡張子を変更しました。

## 作業内容
- Inline2json#createで受け付けるContent-typeをplain/textのみに変更
- TextaeAnnotationController#createで受け付けるContent-typeのtext/markdownをtext/plainに変更
- 各テストの修正
- READMEの調整
  - MIME-typeと拡張子の変更
  - リクエストのサンプルにミスがあったため合わせて修正

## 動作確認
### POST conversions/inline2json
text/plain以外でリクエストするとエラーが発生します。
```
➜  pubannotation git:(fix/simple_inline_annotation_mime_type_and_file_extension) ✗ curl -X POST http://localhost:3000/conversions/inline2json \
-H 'Content-Type: text/markdown' \
-d "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].

[Person]: https://example.com/Person
[Organization]: https://example.com/Organization"
ERROR: Invalid content type. Please set text/plain to Content-Type.%
```

text/plainでリクエストすると変換結果が返ります。
```
➜  pubannotation git:(fix/simple_inline_annotation_mime_type_and_file_extension) ✗ curl -X POST http://localhost:3000/conversions/inline2json \
-H 'Content-Type: text/plain' \
-d "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].

[Person]: https://example.com/Person
[Organization]: https://example.com/Organization"
{"text":"Elon Musk is a member of the PayPal Mafia.","denotations":[{"span":{"begin":0,"end":9},"obj":"https://example.com/Person"},{"span":{"begin":29,"end":41},"obj":"https://example.com/Organization"}],"config":{"entity types":[{"id":"https://example.com/Person","label":"Person"},{"id":"https://example.com/Organization","label":"Organization"}]}}
```

### POST /textae
こちらもSimpleInlineFormatとして読ませるのであればtext/plainでなければエラーが起きます。
```
➜  pubannotation git:(fix/simple_inline_annotation_mime_type_and_file_extension) ✗ curl -X POST http://localhost:3000/textae \
  -H "Content-Type: text/markdown" \
  -d "[Elon Musk][Person] is a member of the PayPal Mafia.

      [Person]: https://example.com/Person"
{"error":"Invalid content-type. Please set the correct content-type according to the request."}%  
```

text/plainでリクエストするとHTMLの生成に成功します。
```
 ➜  pubannotation git:(fix/simple_inline_annotation_mime_type_and_file_extension) ✗ curl -X POST http://localhost:3000/textae \
  -H "Content-Type: text/plain" \
  -d "[Elon Musk][Person] is a member of the PayPal Mafia.

      [Person]: https://example.com/Person"
{"message":"Request was successfully processed. To see the generated textae html, send GET request to result_url.","result_url":"http://localhost:3000/textae/0a331a4e-ed41-48eb-9741-6002dfc870a2"}%
```
## テスト
```
➜  pubannotation git:(fix/simple_inline_annotation_mime_type_and_file_extension) ✗ bundle exec rspec
............................................................................................................................................................................................................................................................................................

Finished in 19.25 seconds (files took 0.86477 seconds to load)
284 examples, 0 failures
```