### PR TITLE
Update textae version on TextaeAnnotations#show

### DIFF
--- a/app/views/textae_annotations/show.html.erb
+++ b/app/views/textae_annotations/show.html.erb
@@ -4,8 +4,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="https://textae.pubannotation.org/lib/css/textae-13.6.1.min.css">
-  <script src="https://textae.pubannotation.org/lib/textae-13.6.1.min.js"></script>
+  <link rel="stylesheet" href="https://textae.pubannotation.org/lib/css/textae-13.7.0.min.css">
+  <script src="https://textae.pubannotation.org/lib/textae-13.7.0.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## 概要
POST /textaeで生成するHTMLのtextaeバージョンが古くなっており、その影響で生成したHTMLではTextAEを起動できていませんでした。
この問題を修正しました。

## 修正前
|<img width="968" alt="image" src="https://github.com/user-attachments/assets/43250abf-1252-4ff2-9b29-66fd7aa640c7" />|
|:-|

## 修正後
|<img width="680" alt="image" src="https://github.com/user-attachments/assets/93be7f4a-3ef4-47c2-86a4-7c4603f5d40f" />|
|:-|
