### PR TITLE
Updated textae version

### DIFF
--- a/app/views/textae_annotations/show.html.erb
+++ b/app/views/textae_annotations/show.html.erb
@@ -4,8 +4,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="https://textae.pubannotation.org/lib/css/textae-13.7.0.min.css">
-  <script src="https://textae.pubannotation.org/lib/textae-13.7.0.min.js"></script>
+  <link rel="stylesheet" href="https://textae.pubannotation.org/lib/css/textae-13.8.1.min.css">
+  <script src="https://textae.pubannotation.org/lib/textae-13.8.1.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## 概要
POST methodでTextAEを開く機能ではTextAEサーバーからJS, CSSを取得しています。
TextAEサーバーのバージョンが更新されJS, CSSを取得できなくなっていたため、バージョンを合わせることで問題を解決しました。

## 動作確認
|<img width="1431" alt="image" src="https://github.com/user-attachments/assets/ea346f34-c285-451b-8663-f3801e820d0b" />|
|:-|