### PR TITLE
Change gem source for 'simple_inline_text_annotation' to RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'elasticsearch-rails', '~> 7.2'
 gem 'faraday'
 gem 'stardog-rb', git: 'https://github.com/jdkim/stardog-rb.git'
 gem 'tao_rdfizer', '~> 0.12'
-gem 'simple_inline_text_annotation', github: 'Tamada-Arino/simple-inline-text-annotation'
+gem 'simple_inline_text_annotation'
 
 # Use to clear page or fragment caches in app/controllers/doc_sweeper.rb
 gem 'rails-observers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,6 @@ GIT
       thor (>= 0.14)
 
 GIT
-  remote: https://github.com/Tamada-Arino/simple-inline-text-annotation.git
-  revision: 4211fb0836afe67d3df0b7f5bcef873f4cca21b7
-  specs:
-    simple_inline_text_annotation (0.1.0)
-
-GIT
   remote: https://github.com/brianhempel/active_record_union.git
   revision: 8ebe558709aabe039abd24e3e7dd4d4354a6de88
   specs:
@@ -389,6 +383,7 @@ GEM
       logger (>= 1.6.2)
       rack (>= 3.1.0)
       redis-client (>= 0.23.2)
+    simple_inline_text_annotation (0.1.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -480,7 +475,7 @@ DEPENDENCIES
   ruby-dictionary
   rubyzip
   sidekiq
-  simple_inline_text_annotation!
+  simple_inline_text_annotation
   sprockets-rails
   stackprof
   stardog-rb!


### PR DESCRIPTION
## 概要
`gem 'simple_inline_text_annotation'`の参照元をGithubリポジトリからRubyGems.orgに変更しました。

## 動作確認
`bundle install`を実行し、エラーが出ることなくインストールが終了すること、
`gem 'simple_inline_text_annotation'`の参照元がRubyGemsになっていることを確認しました。