### PR TITLE
Update simple-inline-text-annotation gem to version 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'elasticsearch-rails', '~> 7.2'
 gem 'faraday'
 gem 'stardog-rb', git: 'https://github.com/jdkim/stardog-rb.git'
 gem 'tao_rdfizer', '~> 0.12'
-gem 'simple_inline_text_annotation'
+gem 'simple_inline_text_annotation', '~> 1.1'
 
 # Use to clear page or fragment caches in app/controllers/doc_sweeper.rb
 gem 'rails-observers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ GEM
       logger (>= 1.6.2)
       rack (>= 3.1.0)
       redis-client (>= 0.23.2)
-    simple_inline_text_annotation (0.1.0)
+    simple_inline_text_annotation (1.1.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -475,7 +475,7 @@ DEPENDENCIES
   ruby-dictionary
   rubyzip
   sidekiq
-  simple_inline_text_annotation
+  simple_inline_text_annotation (~> 1.1)
   sprockets-rails
   stackprof
   stardog-rb!


### PR DESCRIPTION
## 関連issue

https://github.com/Tamada-Arino/simple-inline-text-annotation/issues/28

## 概要

リレーション記法に対応したsimple_inline_text_annotation gemのバージョンを指定して、適用させました。

## 動作確認

ローカルのrailsアプリが動作している状態で以下のコマンドを実行し、それぞれ意図した結果が返ってくることを確認しました。

```bash
$ curl -X POST http://localhost:3000/conversions/inline2json \
-H "Content-Type: text/plain" \      
--data "[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization]."
```

```bash
$ curl -X POST http://localhost:3000/conversions/json2inline \
-H "Content-Type: application/json" \
-d '{
  "text": "Elon Musk is a member of the PayPal Mafia.",
  "denotations": [
    {"id": "T1", "span": {"begin": 0, "end": 9}, "obj": "Person"},
    {"id": "T2","span": {"begin": 29, "end": 41}, "obj": "Organization"}
  ],
  "relations": [
    {"pred": "member_of", "subj": "T1", "obj": "T2"}
  ]
}'
```
<img width="1053" alt="スクリーンショット 2025-05-08 14 29 06" src="https://github.com/user-attachments/assets/48ac5a6d-e2c5-4c86-bb1b-6761d1314ddb" />
