### PR TITLE
Fix: Ensure all specified terms must match (AND search) instead of any (OR search) in attributes

### DIFF
--- a/app/models/concerns/term_search_concern.rb
+++ b/app/models/concerns/term_search_concern.rb
@@ -7,6 +7,8 @@ module TermSearchConcern
     scope :with_terms, lambda { |terms, user, predicates, project_names|
       with_attributes = search_in_attributes(terms, user, predicates, project_names)
                           .select(:doc_id, 'docs.sourcedb', :'docs.sourceid')
+                          .group(:doc_id, 'docs.sourcedb', :'docs.sourceid')
+                          .having('COUNT(DISTINCT attrivutes.obj) = ?', terms.size)
 
       if predicates.nil? || predicates&.include?('denotes')
         with_denotations = search_in_denotations(terms, user, project_names)

--- a/app/models/concerns/term_search_concern.rb
+++ b/app/models/concerns/term_search_concern.rb
@@ -25,6 +25,8 @@ module TermSearchConcern
     scope :with_terms_with_begin_end, lambda { |terms, user, predicates, project_names|
       with_attributes = search_in_attributes(terms, user, predicates, project_names)
                           .select(:doc_id, :begin, :end, 'docs.sourcedb', :'docs.sourceid')
+                          .group(:doc_id, :begin, :end, 'docs.sourcedb', :'docs.sourceid')
+                          .having('COUNT(DISTINCT attrivutes.obj) = ?', terms.size)
 
       if predicates&.include?('denotes')
         with_denotations = search_in_denotations(terms, user, project_names)


### PR DESCRIPTION
## 概要
- termsに複数文字列を指定していた場合、termsのいずれかに該当していれば検索結果として取得してしまう問題の対応を行いました
   - termsが複数ある場合、すべてに合致しているものを取得できるようにクエリを変更しました

## 動作確認
- ローカル環境に、検索時に取得される意図しないドキュメントと、取得して欲しいドキュメントを追加

   - 検索時に取得される意図しないドキュメントは、[ここ](https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=doc&term_search_controller_query%5Bterms%5D=https%3A%2F%2Fglycosmos.org%2Fglycans%2Fshow%2FG00053MO%2CMONDO%3A0009831&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bprojects%5D=GlyCosmos15-Glycan%2CGlyCosmos15-MONDO&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10&commit=Search)から2つ


   - 取得して欲しいドキュメントは[ここ](https://pubannotation.org/collections/GlyCosmos15/search?query=SELECT+DISTINCT+%3Fs3%0D%0AWHERE+%7B%0D%0A%09GRAPH+prj%3AGlyCosmos15-Glycan+%7B%0D%0A%09%09%3Fo1+tao%3Adenoted_by+%3Fs1+.%0D%0A%09%09%3Fo1+a+%3Chttps%3A%2F%2Fglycosmos.org%2Fglycans%2Fshow%2FG00053MO%3E+.%0D%0A%09%7D%0D%0A%09%09%09%09%09%09%0D%0A%09GRAPH+prj%3AGlyCosmos15-MONDO+%7B%0D%0A%09%09%3Fo2+tao%3Adenoted_by+%3Fs2+.%0D%0A%09%09%3Fo2+a+%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FMONDO_0009831%3E%0D%0A%09%7D%0D%0A%0D%0A%09GRAPH+prj%3AGlyCosmos15-Sentences+%7B%0D%0A%09%09%3Fo3+tao%3Adenoted_by+%3Fs3+.%0D%0A%09%7D%0D%0A%0D%0A%09%3Fs3+tao%3Acontains+%3Fs1+.%0D%0A%09%3Fs3+tao%3Acontains+%3Fs2+.%0D%0A%7D&template_select=&show_mode=textae&project_name=&projects=GlyCosmos15-Glycan%2CGlyCosmos15-MONDO)から2つピックアップしました

- 検索結果を表示するページを確認
   - http://localhost:3000/term_search?term_search_controller_query%5Bblock_type%5D=doc&term_search_controller_query%5Bterms%5D=https%3A%2F%2Fglycosmos.org%2Fglycans%2Fshow%2FG00053MO%2CMONDO%3A0009831&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bprojects%5D=GlyCosmos15-Glycan%2CGlyCosmos15-MONDO&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10&commit=Search
- masterブランチで、意図しないドキュメントと取得して欲しいドキュメントがすべて表示されていることを確認しました

![localhost_3000_term_search_term_search_controller_query%5Bblock_type%5D=doc term_search_controller_query%5Bterms%5D=https%3A%2F%2Fglycosmos org%2Fglycans%2Fshow%2FG00053MO%2CMONDO%3A0009831 term_search_controller_query%5Bpredicates%5D= term](https://github.com/user-attachments/assets/bcc32da3-45ea-474a-b0fb-577bfd342b29)

- 作業ブランチで、取得して欲しいドキュメントのみが表示されていることを確認しました
![localhost_3000_term_search_term_search_controller_query%5Bblock_type%5D=doc term_search_controller_query%5Bterms%5D=https%3A%2F%2Fglycosmos org%2Fglycans%2Fshow%2FG00053MO%2CMONDO%3A0009831 term_search_controller_query%5Bpredicates%5D=  (1)](https://github.com/user-attachments/assets/4fecafda-e7dd-46f9-a31d-62e07ac63ef3)
