### PR TITLE
Fix doc spec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,5 +70,5 @@ jobs:
           ELASTICSEARCH_URL: http://localhost:9200
 
         run: |
-          bin/rails db:setup
+          bin/rails db:create db:schema:load
           bundle exec rspec


### PR DESCRIPTION
## 概要

https://github.com/pubannotation/pubannotation/actions/runs/15269745393

#196 でseedにPubMedのドキュメントを追加したことによって、一部のSpecが落ちる問題が発生しました。この対応を行いました
- CI上ではdb:seedを実行していたので、db:seedを実行しないようにワークフローを修正
   - テストで必要なデータはseedではなく書くテストファイルで作成するようにしました

## 動作確認

- cherry-pickでPR作成時にテストが実行されるようにする変更を一時的に取り込みました
   - この変更自体は別のPRを用意しています
- CI上でテストが通るようになったことを確認しました
   - [Ruby CI / test (pull_request)](https://github.com/pubannotation/pubannotation/actions/runs/15293572326/job/43017458246?pr=198)
