### PR TITLE
Update minor gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,7 +424,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    websocket-driver (0.7.7)
+    websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## 概要

`bundle outdated`を実行し、アップデートできるgemのうちマイナーバージョンかパッチバージョンが変更になっているgemのバージョンを上ました。

- before

<img width="593" alt="スクリーンショット 2025-06-06 11 31 48" src="https://github.com/user-attachments/assets/4efdc800-65ce-4294-82b8-dc8c55ff863c" />

- after

<img width="622" alt="スクリーンショット 2025-06-06 15 14 31" src="https://github.com/user-attachments/assets/56844003-09ae-4dbf-a1d1-e222c051f993" />


## 動作確認

`bin/setup`を実行して、問題なくアプリが立ち上がることを確認しました
`bundle exec rspec`を実行して、すべてのテストが通ることをしました

<img width="1299" alt="スクリーンショット 2025-06-06 15 23 38" src="https://github.com/user-attachments/assets/3ff5a905-27ee-47e4-8e82-6f4b3300e819" />
