### PR TITLE
Limit the number of jobs for parallel processing

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 2
+:concurrency: 1
 :max_retries: 0
 :queues:
   - general


### PR DESCRIPTION
## 概要

- 同時に実行するジョブ数を1にしました

## 動作確認

- 作業ブランチ
   - ブラウザを4つ並べて、それぞれに1.5MBほどのファイルを選択しました
   - ほぼ同時に処理を開始させました
   - 同時に実行されるジョブが1つのみになっていることを確認しました
   - すべての処理が止まることなく終了することを確認しました

<img width="1920" alt="スクリーンショット 2025-06-11 17 19 04" src="https://github.com/user-attachments/assets/52ceda61-52cc-47b9-a876-600655937c69" />

<img width="764" alt="スクリーンショット 2025-06-12 11 55 40" src="https://github.com/user-attachments/assets/cf42cc87-73a3-4ff9-9f8a-3a290da65dc8" />


<img width="781" alt="スクリーンショット 2025-06-12 11 57 06" src="https://github.com/user-attachments/assets/61d517fa-42e0-487d-9c1c-8508c0e9d9ec" />

- masterブランチで上記手順を行いました
   - job一覧で2つ同時に処理されていることを確認
   - 最初に実行されたジョブが終わらないことを確認
      
<img width="863" alt="スクリーンショット 2025-06-11 17 28 54" src="https://github.com/user-attachments/assets/4ca92f79-7232-405c-b5a3-97a715300e3e" />

<img width="777" alt="スクリーンショット 2025-06-11 17 32 59" src="https://github.com/user-attachments/assets/af18b093-7871-4f32-a293-28653741b83d" />