### PR TITLE
Fix handling of unique constraint errors to prevent process interruption

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -459,6 +459,12 @@ class Project < ActiveRecord::Base
       }
     end
 
+    # The use of insert_all is not primarily intended to improve performance.
+    # It is intended to avoid violating the unique constraint (combination of project_id and doc_id) of the ProjectDoc table
+    # when updating simultaneously from multiple threads.
+    # Adding associations with doc.projects << self could result in duplicate associations being inserted at the same time.
+    # Using the unique_by option to the insert_all method allows bulk insertion while avoiding uniqueness constraint violations.
+    # This allows associations to be safely added even if they are running concurrently in different threads.
     result = ProjectDoc.insert_all(
       records,
       unique_by: %i[project_id doc_id]


### PR DESCRIPTION
## 概要
ファイル処理中にユニーク制約エラーが発生し、以降の処理が続行できない問題の対応を行いました
 ```
class: ActiveRecord::RecordNotUnique, message: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_project_docs_on_project_id_and_doc_id" DETAIL: Key (project_id, doc_id)=(10, 898) already exists. , backt ... (truncated)
```
`ActiveRecord::RecordNotUnique`が発生するメソッド内で、project_idとdoc_idの組み合わせがユニークになるものだけをinsert_allで作成するようにしました

## 動作確認
- 1.5MBのjsonlファイルを処理させて、masterブランチと同じ動作、メッセージになることを確認しました
- 同じ300MBのtgzファイルを同時に処理させ、`ActiveRecord::RecordNotUnique`が発生する場合、以降の処理も実行されているらしいことを確認
   - すべてのJobが`finished`になるところまでは確認できませんでした
   - https://bugs.ruby-lang.org/issues/21398 で行ったバグ報告の症状と同じかと思われます
      - この報告が対応されたら改善されるかと推測しています
- 処理がハングした時、ユニーク制約が原因で止まっていないことを確認しました
- 作業ブランチ内で作成された`project_docs`テーブルのレコード中身が、masterブランチで作成されたレコードと同じ内容になっていることを確認しました