### PR TITLE
Reverse execution order of @jobs assignment and Job.reap_zombies

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -6,8 +6,8 @@ class JobsController < ApplicationController
 	# GET /jobs
 	# GET /jobs.json
 	def index
-		@jobs = @organization&.jobs.order(:created_at)
 		Job.reap_zombies
+		@jobs = @organization&.jobs.order(:created_at)
 
 		respond_to do |format|
 			format.html { redirect_to organization_path if @jobs.nil? || @jobs.empty? }


### PR DESCRIPTION
## 概要

#208 で実装した`Job.reap_zombies`と`@jobs`の取得の順番を修正しました


## 動作確認

#208 と同様に、Sidekiqが動作していない状態でJob一覧に遷移すると、停止したJobが`finished`になることを確認しました