### PR TITLE
Update rack-cors gem and rdoc gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,8 +303,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.16)
-    rack-cors (2.0.2)
-      rack (>= 2.0.0)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
     rack-protection (4.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
       zeitwerk (~> 2.6)
     raindrops (0.20.1)
     rake (13.3.0)
-    rdoc (6.14.1)
+    rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
     recaptcha (5.19.0)


### PR DESCRIPTION
## 概要

#210 で対応が漏れていた `rack-cors` gemのアップデートを行いました。
また、`rdoc` gemの最新版があったためこちらもアップデートしました。

| before | after |
|-------|------|
| <img width="571" alt="スクリーンショット 2025-07-04 14 13 40" src="https://github.com/user-attachments/assets/b83b0f54-64ac-422d-ad8f-ab5e30292502" /> | <img width="588" alt="スクリーンショット 2025-07-04 14 13 12" src="https://github.com/user-attachments/assets/4c38c5e9-1d58-488e-8820-cb4f434ec2af" /> |

## 動作確認
```
% curl -i -X OPTIONS http://localhost:3000/ \                                                                
                                   -H "Origin: http://example.com" \
                                   -H "Access-Control-Request-Method: GET"
```
```
% curl -i -X OPTIONS http://localhost:3000/ \
                                   -H "Origin: null" \              
                                   -H "Access-Control-Request-Method: GET"
```
それぞれを実行して、originが http://example.com のときはレスポンスヘッダーにCORS関連ヘッダーが含まれていること、
originがnullのときはレスポンスヘッダーにCORS関連ヘッダーが含まれていないことを確認しました。