### PR TITLE
Fix test environment setup to avoid Redis/Elasticsearch connection errors

### DIFF
--- a/spec/controllers/docs_controller_span_query_spec.rb
+++ b/spec/controllers/docs_controller_span_query_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'DocsController#show with span - N+1 query prevention', type: :request do
   # Stub Elasticsearch to avoid connection errors
   before do
-    allow_any_instance_of(Doc).to receive(:__elasticsearch__).and_return(double(index_document: true, delete_document: true))
+    allow(Elasticsearch::IndexQueue).to receive(:index_doc)
+    allow(Elasticsearch::IndexQueue).to receive(:delete_doc)
   end
 
   let(:user) { create(:user) }
@@ -80,7 +81,8 @@ end
 # Separate test for the batch loading query itself at model level
 RSpec.describe 'Denotation batch counting for span', type: :model do
   before do
-    allow_any_instance_of(Doc).to receive(:__elasticsearch__).and_return(double(index_document: true, delete_document: true))
+    allow(Elasticsearch::IndexQueue).to receive(:index_doc)
+    allow(Elasticsearch::IndexQueue).to receive(:delete_doc)
   end
 
   let(:user) { create(:user) }

--- a/spec/factories/project_docs.rb
+++ b/spec/factories/project_docs.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     denotations_num { 0 }
     blocks_num { 0 }
     relations_num { 0 }
+
+    after(:create) do |project_doc|
+      Doc.increment_counter(:projects_num, project_doc.doc_id)
+    end
   end
 end

--- a/spec/models/doc/bulk_update_docs_counts_spec.rb
+++ b/spec/models/doc/bulk_update_docs_counts_spec.rb
@@ -33,42 +33,38 @@ RSpec.describe Doc, '.bulk_update_docs_counts', type: :model do
       doc1.reload
       expect(doc1.denotations_num).to eq(3)
       expect(doc1.blocks_num).to eq(2)
-      expect(doc1.projects_num).to eq(1)
 
       doc2.reload
       expect(doc2.denotations_num).to eq(5)  # Only from project1
       expect(doc2.blocks_num).to eq(1)        # Only from project2
-      expect(doc2.projects_num).to eq(2)      # Two projects
 
       doc3.reload
       expect(doc3.denotations_num).to eq(0)
       expect(doc3.blocks_num).to eq(0)
-      expect(doc3.projects_num).to eq(0)
     end
   end
 
   describe 'updating specific docs' do
     it 'updates only specified docs' do
       # Set initial wrong counts
-      doc1.update_columns(denotations_num: 999, blocks_num: 999, projects_num: 999)
-      doc2.update_columns(denotations_num: 999, blocks_num: 999, projects_num: 999)
-      doc3.update_columns(denotations_num: 999, blocks_num: 999, projects_num: 999)
+      # Note: projects_num is maintained incrementally via association callbacks,
+      # so it is intentionally not re-aggregated by bulk_update_docs_counts.
+      doc1.update_columns(denotations_num: 999, blocks_num: 999)
+      doc2.update_columns(denotations_num: 999, blocks_num: 999)
+      doc3.update_columns(denotations_num: 999, blocks_num: 999)
 
       # Update only doc1 and doc2
       Doc.bulk_update_docs_counts(doc_ids: [doc1.id, doc2.id])
 
       doc1.reload
       expect(doc1.denotations_num).to eq(3)
-      expect(doc1.projects_num).to eq(1)
 
       doc2.reload
       expect(doc2.denotations_num).to eq(5)
-      expect(doc2.projects_num).to eq(2)
 
       # doc3 should remain unchanged
       doc3.reload
       expect(doc3.denotations_num).to eq(999)
-      expect(doc3.projects_num).to eq(999)
     end
   end
 
@@ -105,7 +101,6 @@ RSpec.describe Doc, '.bulk_update_docs_counts', type: :model do
 
       doc2.reload
       expect(doc2.denotations_num).to eq(15)  # 5 + 10
-      expect(doc2.projects_num).to eq(3)      # Three projects now
     end
 
     it 'sets counts to zero when annotations are deleted' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,13 @@ RSpec.configure do |config|
   # Include ActiveSupport time helpers (travel_to, freeze_time, etc.)
   config.include ActiveSupport::Testing::TimeHelpers
 
+  # Stub Sidekiq::Queue#size to avoid Redis connection errors in tests.
+  # StoreAnnotationsCollectionUploadJob#wait_for_queue_space checks the queue size
+  # before enqueuing child jobs. Without Redis, this raises CannotConnectError.
+  config.before(:each) do
+    allow_any_instance_of(Sidekiq::Queue).to receive(:size).and_return(0)
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = []
 

--- a/spec/support/elasticsearch_helper.rb
+++ b/spec/support/elasticsearch_helper.rb
@@ -140,6 +140,23 @@ module ElasticsearchTestHelper
 end
 
 RSpec.configure do |config|
+  # Stub IndexQueue for all non-elasticsearch tests to avoid Redis connection errors.
+  # ElasticsearchIndexable registers after_commit callbacks that push to Redis;
+  # non-ES tests don't need real indexing and Redis is not guaranteed to be running.
+  config.before(:each) do |example|
+    unless example.metadata[:elasticsearch]
+      allow(Elasticsearch::IndexQueue).to receive(:index_doc)
+      allow(Elasticsearch::IndexQueue).to receive(:delete_doc)
+      allow(Elasticsearch::IndexQueue).to receive(:update_embedding)
+      allow(Elasticsearch::IndexQueue).to receive(:index_docs)
+      allow(Elasticsearch::IndexQueue).to receive(:add_project_membership)
+      allow(Elasticsearch::IndexQueue).to receive(:remove_project_membership)
+      allow(Elasticsearch::IndexQueue).to receive(:add_project_memberships)
+      allow(Elasticsearch::IndexQueue).to receive(:remove_project_memberships)
+      allow(Elasticsearch::IndexQueue).to receive(:schedule_processing)
+    end
+  end
+
   config.before(:suite) do
     if ElasticsearchTestHelper.elasticsearch_available?
       ElasticsearchTestHelper.setup_test_index


### PR DESCRIPTION
## 概要

https://github.com/pubannotation/pubannotation/actions/runs/24604603682/job/71948708555

落ちているCIの対応を行います。

- spec/support/elasticsearch_helper.rb

  - ElasticsearchIndexable が`after_commit :queue_es_index`コールバックを登録しており、テストで任意のモデルを create するたびにRedisへの接続が発生していた
    - spec/support/elasticsearch_helper.rb は :elasticsearch タグ付きテスト専用の設定しかなく、それ以外のすべてのテストが影響を受けていた。
  
  - RSpec.configure ブロックに before(:each) を追加し`:elasticsearch`タグのないテストでは `Elasticsearch::IndexQueue`のすべてのクラスメソッドをスタブするように変更

- spec/factories/project_docs.rb
  - ProjectDoc を直接作成すると doc.projects の after_add コールバックが発火しない
  - after(:create) を追加、production の`increment_docs_projects_counter`と同じ`Doc.increment_counter`を呼ぶ

- spec/controllers/docs_controller_span_query_spec.rb
  - `__elasticsearch__` は `elasticsearch-model` gem 由来のメソッドで、カスタム ElasticsearchIndexable concern への移行時に削除された
  - スタブ先を`Elasticsearch::IndexQueue`クラスメソッドに変更

- spec/rails_helper.rb
  - StoreAnnotationsCollectionUploadJob の wait_for_queue_space メソッドが子ジョブをエンキューする前に Sidekiq のキューサイズを確認するが、テスト環境では Redis が起動していないため、この呼び出しでRedisClient::CannotConnectError が発生し、その後の BatchJobTracking.create! まで到達できなくなっていた
  - Sidekiq::Queue#size を全テストでスタブして常に 0 を返すようにした
 
- spec/models/doc/bulk_update_docs_counts_spec.rb
  - specの期待値が間違っていたので削除
  - https://luxiar.slack.com/archives/C01S85B6SF9/p1780470361573029
