### PR TITLE
Fix migration to detect unique index in AddUniqueIndexToProjectDocs

### DIFF
--- a/db/migrate/20250726014130_add_unique_index_to_project_docs.rb
+++ b/db/migrate/20250726014130_add_unique_index_to_project_docs.rb
@@ -2,7 +2,7 @@ class AddUniqueIndexToProjectDocs < ActiveRecord::Migration[8.0]
   INDEX_NAME = "index_project_docs_on_project_id_and_doc_id"
 
   def up
-    if index_exists?(:project_docs, [:project_id, :doc_id], unique: false, name: INDEX_NAME)
+    if index_exists?(:project_docs, [:project_id, :doc_id], name: INDEX_NAME)
       remove_index :project_docs, name: INDEX_NAME
     end
     add_index :project_docs, [:project_id, :doc_id], unique: true, name: "index_project_docs_on_project_id_and_doc_id"


### PR DESCRIPTION
## 概要

https://luxiar.slack.com/archives/C01S85B6SF9/p1780475828570929

- bin/setupの実行時にマイグレーションが失敗したのでその対応
  - `db/migrate/20250726014130_add_unique_index_to_project_docs.rb`のupで、すでにユニークな`project_docs`インデックスが存在している場合に index_exists? の unique: false 条件が false になるため remove_index がスキップされ、add_index が「インデックスが既に存在する」エラーで失敗していた
  - unique: false を削除(ユニーク・非ユニーク問わず存在確認)したところ動作するようになった


## 動作確認

bin/setup 実行時、エラーが起きることなくアプリが立ち上がることを確認しました