### PR TITLE
Update elasticsearch gem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,16 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       # https://github.com/elastic/elastic-github-actions/tree/master/elasticsearch
       - name: Configure sysctl limits

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
           stack-version: 9.4.1
+          security-enabled: false
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Runs Elasticsearch
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
-          stack-version: 7.6.0
+          stack-version: 9.4.1
 
       - uses: actions/checkout@v4
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,8 @@ gem "omniauth-rails_csrf_protection"
 gem 'omniauth-google-oauth2'
 gem 'rubyzip'
 gem 'zip-zip'
-# Elasticsearch 8.x - direct client without elasticsearch-model/rails
-gem 'elasticsearch', '~> 8.12'
+# Elasticsearch 9.x - direct client without elasticsearch-model/rails
+gem 'elasticsearch', '~> 9.0'
 gem 'httpx', '~> 1.2'  # HTTP client for embedding service
 gem 'faraday'
 gem 'stardog-rb', git: 'https://github.com/jdkim/stardog-rb.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,11 +164,11 @@ GEM
     elastic-transport (8.5.2)
       faraday (< 3)
       multi_json
-    elasticsearch (8.19.3)
+    elasticsearch (9.4.1)
       elastic-transport (~> 8.3)
-      elasticsearch-api (= 8.19.3)
-      ostruct
-    elasticsearch-api (8.19.3)
+      elasticsearch-api (= 9.4.1)
+    elasticsearch-api (9.4.1)
+      base64
       multi_json
     erb (6.0.4)
     erubi (1.13.1)
@@ -298,7 +298,6 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    ostruct (0.6.3)
     pg (1.5.9)
     pp (0.6.3)
       prettyprint
@@ -466,7 +465,7 @@ DEPENDENCIES
   devise
   diff-lcs
   dotenv-rails
-  elasticsearch (~> 8.12)
+  elasticsearch (~> 9.0)
   facebox-rails!
   factory_bot_rails
   faraday

--- a/app/models/search_results.rb
+++ b/app/models/search_results.rb
@@ -169,7 +169,7 @@ class SearchResults
     end
 
     def id
-      hit['_id']
+      hit['_id'].to_i
     end
 
     def score

--- a/config/elasticsearch/mappings/docs_v1.json
+++ b/config/elasticsearch/mappings/docs_v1.json
@@ -3,6 +3,7 @@
     "number_of_shards": 3,
     "number_of_replicas": 1,
     "refresh_interval": "1s",
+    "index.mapping.exclude_source_vectors": false,
     "analysis": {
       "analyzer": {
         "standard_normalization": {


### PR DESCRIPTION
## 概要

gemのアップデート計画

PR | カテゴリ | 対象gem | 状態
--- | --- | --- | ---
1 | Ruby標準ライブラリ系・低リスクユーティリティ | benchmark, bigdecimal, date, debug, erb, io-console, irb, json, net-http, net-imap, pp, psych, reline, rdoc, stringio, timeout, uri, bootsnap, concurrent-ruby, i18n, mime-types-data, msgpack, rake, snaky_hash, thor, zeitwerk | ✅
2 | テスト関連 | factory_bot, factory_bot_rails, rspec-core, rspec-mocks, rspec-rails, rspec-support, diff-lcs（1→2 メジャー） | ✅
3 | Web・HTTP・ネットワーク層 | rack, rack-session, rack-protection, rackup, puma（6→8 メジャー）, nio4r, faraday, faraday-net_http, addressable, public_suffix, http-2, http-cookie, httpx, redis-client, connection_pool,   rack-mini-profiler（3→4 メジャー） | ✅
4 | 認証・セキュリティ系 | bcrypt, devise（4→5 メジャー）, jwt, omniauth, omniauth-google-oauth2, omniauth-oauth2, omniauth-rails_csrf_protection（1→2 メジャー）, oauth2, recaptcha, loofah, rails-html-sanitizer, nokogiri | ✅
5 | その他アプリ依存gem | friendly_id, globalid, hashie, htmlentities, libxml-ruby（5→6 メジャー）, mail, multi_json, multi_xml, responders, rubyzip（2→3 メジャー）, sidekiq, terser, web-console, stackprof, jquery-rails, dotenv, dotenv-rails, active_record_union, foreman, elastic-transport, simple_inline_text_annotation（1→2 メジャー） | ✅
6 | elasticsearch | elasticsearch |

以上のうち、elasticsearch gemのアップデートを行いました。

### Elasticserch 9.xの破壊的変更について
 dense_vector が _source に保存されなくなった
  
 (https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html

> By default, dense_vector fields are not stored in _source on disk

ES 9.2 以降、index.mapping.exclude_source_vectors がデフォルト true になり、インデックス付き dense_vector フィールドは _source から除外されるようになる

インデックス設定で `index.mapping.exclude_source_vectors": false`を指定することで従来の動作に戻すことが可能
→ [Set exclude_source_vectors false to keep dense_vector in _source](https://github.com/pubannotation/pubannotation/pull/242/commits/adfd22004881c6bf66fdfee76b2083ecb481fbaa) で対応


### .`github/workflows/main.yml`の変更について

https://github.com/pubannotation/pubannotation/actions/runs/26991897224/job/79653557836 の結果を踏まえて修正
security-enabled: false を指定することで TLSと認証を無効化し、従来通り HTTP でアクセスできるようにした

https://github.com/Tamada-Arino/pubannotation/actions/runs/26992088945/job/79654133989 の結果を踏まえテスト実行前にredisサーバーを起動するように修正



## 動作確認

- bin/setupでアプリが立ち上がることを確認
- 全てのspecが通ることを確認
  - elasticsearch関連のspecも含む
