### PR TITLE
[codex] Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/brianhempel/active_record_union.git
-  revision: 8ebe558709aabe039abd24e3e7dd4d4354a6de88
+  revision: 6ce772899bfd711e74f3ca696480829c7d978ea7
   specs:
-    active_record_union (1.3.0)
+    active_record_union (1.4.0)
       activerecord (>= 6.0)
 
 GIT
@@ -132,8 +132,8 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    auth-sanitizer (0.1.5)
-      version_gem (~> 1.1, >= 1.1.9)
+    auth-sanitizer (0.2.1)
+      version_gem (~> 1.1, >= 1.1.10)
     base64 (0.3.0)
     bcrypt (3.1.22)
     bigdecimal (4.1.2)
@@ -216,7 +216,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.19.8)
+    json (2.19.9)
     jwt (3.2.0)
       base64
     kaminari (1.2.2)
@@ -253,7 +253,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     multi_json (1.21.1)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
@@ -274,15 +274,15 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth2 (2.0.20)
-      auth-sanitizer (~> 0.1, >= 0.1.3)
+    oauth2 (2.0.23)
+      auth-sanitizer (~> 0.2, >= 0.2.1)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.4)
-      version_gem (~> 1.1, >= 1.1.9)
+      snaky_hash (~> 2.0, >= 2.0.6)
+      version_gem (~> 1.1, >= 1.1.11)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
@@ -301,7 +301,8 @@ GEM
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
-    pg (1.5.9)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -372,7 +373,7 @@ GEM
       psych (>= 4.0.0)
       tsort
     recaptcha (5.21.2)
-    redis-client (0.29.0)
+    redis-client (0.30.0)
       connection_pool
     reline (0.6.3)
       io-console (~> 0.5)
@@ -397,16 +398,16 @@ GEM
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
     ruby-dictionary (1.1.1)
-    rubyzip (3.3.1)
+    rubyzip (3.4.0)
     securerandom (0.4.1)
-    sidekiq (8.0.10)
-      connection_pool (>= 2.5.0)
-      json (>= 2.9.0)
-      logger (>= 1.6.2)
-      rack (>= 3.1.0)
-      redis-client (>= 0.23.2)
+    sidekiq (8.1.6)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.29.0)
     simple_inline_text_annotation (2.1.0)
-    snaky_hash (2.0.4)
+    snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     sprockets (4.2.2)
@@ -436,7 +437,7 @@ GEM
       raindrops (~> 0.7)
     uri (1.1.1)
     useragent (0.16.11)
-    version_gem (1.1.10)
+    version_gem (1.1.12)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.3.0)


### PR DESCRIPTION
## Summary
- Ran `bundle update --all` and committed the resulting `Gemfile.lock` refresh.
- Updated locked gem versions including `active_record_union`, `oauth2`, `sidekiq`, `pg`, `json`, `msgpack`, `redis-client`, and related transitive dependencies.

## Validation
- `BUNDLE_USER_HOME=/tmp/bundle-home BUNDLE_PATH=/tmp/bundle-path bundle update --all`
- `BUNDLE_USER_HOME=/tmp/bundle-home BUNDLE_PATH=/tmp/bundle-path bundle exec rspec` (360 examples, 0 failures, 61 pending)

## Notes
- The local sandbox prevented writing remote-tracking metadata after push, but the remote branch was created successfully.