### PR TITLE
Add media reference to doc

### DIFF
--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -1130,7 +1130,8 @@ class Doc < ActiveRecord::Base
 	end
 
 	def media_reference_immutable
-		return unless medium_id_changed? && medium_id_was.present?
-		errors.add(:base, 'Media reference cannot be changed after creation')
+		if medium_id_changed?
+			errors.add(:base, 'Media reference cannot be changed after creation')
+		end
 	end
 end

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -70,8 +70,6 @@ class Doc < ActiveRecord::Base
 		:after_remove => [:decrement_docs_projects_counter, :queue_es_project_remove]
 	belongs_to :medium, optional: true
 
-	after_create :capture_original_medium_id
-	after_find :capture_original_medium_id
 	before_validation :resolve_medium_from_source
 	validate :media_reference_immutable, on: :update
 
@@ -1134,6 +1132,7 @@ class Doc < ActiveRecord::Base
 
 	def resolve_medium_from_source
 		return unless media_sourcedb.present? && media_sourceid.present?
+		return if medium_id.present?
 
 		resolved = Medium.find_by(sourcedb: media_sourcedb, sourceid: media_sourceid)
 		if resolved
@@ -1146,15 +1145,8 @@ class Doc < ActiveRecord::Base
 		end
 	end
 
-	def capture_original_medium_id
-		return unless persisted? && has_attribute?(:medium_id)
-		@original_medium_id = medium_id
-	end
-
 	def media_reference_immutable
-		return if @original_medium_id.nil?
-		if medium_id != @original_medium_id
-			errors.add(:base, 'Media reference cannot be changed after creation')
-		end
+		return unless medium_id_changed? && medium_id_was.present?
+		errors.add(:base, 'Media reference cannot be changed after creation')
 	end
 end

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -48,7 +48,7 @@ class Doc < ActiveRecord::Base
 	UserSourcedbSeparator = '@'
 	# before_validation :attach_sourcedb_suffix
 
-	attr_accessor :username, :original_body, :text_aligner
+	attr_accessor :username, :original_body, :text_aligner, :media_sourcedb, :media_sourceid
 
 	has_many :divisions, dependent: :destroy
 	# Paragraph is a kind of division which has label 'p'.
@@ -68,8 +68,11 @@ class Doc < ActiveRecord::Base
 	has_many :projects, through: :project_docs,
 		:after_add => [:increment_docs_projects_counter, :queue_es_project_add],
 		:after_remove => [:decrement_docs_projects_counter, :queue_es_project_remove]
+	belongs_to :medium, optional: true
 
-	validate :media_must_exist, if: -> { media_sourcedb.present? && media_sourceid.present? }
+	after_create :capture_original_medium_id
+	after_find :capture_original_medium_id
+	before_validation :resolve_medium_from_source
 	validate :media_reference_immutable, on: :update
 
 	validates :body,     presence: true
@@ -1069,11 +1072,6 @@ class Doc < ActiveRecord::Base
 
 	def update_all_references_in_sentences = sentences.each { _1.update_references denotations }
 
-	def media
-		return nil unless media_sourcedb.present? && media_sourceid.present?
-		Medium.find_by(sourcedb: media_sourcedb, sourceid: media_sourceid)
-	end
-
 	private
 
 	# default sort order
@@ -1134,14 +1132,28 @@ class Doc < ActiveRecord::Base
 		asciitext
 	end
 
-	def media_must_exist
-		unless Medium.exists?(sourcedb: media_sourcedb, sourceid: media_sourceid)
+	def resolve_medium_from_source
+		return unless media_sourcedb.present? && media_sourceid.present?
+
+		resolved = Medium.find_by(sourcedb: media_sourcedb, sourceid: media_sourceid)
+		if resolved
+			self.medium = resolved
+			self.media_sourcedb = nil
+			self.media_sourceid = nil
+		else
 			errors.add(:base, 'Specified media does not exist')
+			throw :abort
 		end
 	end
 
+	def capture_original_medium_id
+		return unless persisted? && has_attribute?(:medium_id)
+		@original_medium_id = medium_id
+	end
+
 	def media_reference_immutable
-		if will_save_change_to_media_sourcedb? || will_save_change_to_media_sourceid?
+		return if @original_medium_id.nil?
+		if medium_id != @original_medium_id
 			errors.add(:base, 'Media reference cannot be changed after creation')
 		end
 	end

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -48,7 +48,7 @@ class Doc < ActiveRecord::Base
 	UserSourcedbSeparator = '@'
 	# before_validation :attach_sourcedb_suffix
 
-	attr_accessor :username, :original_body, :text_aligner, :media_sourcedb, :media_sourceid
+	attr_accessor :username, :original_body, :text_aligner
 
 	has_many :divisions, dependent: :destroy
 	# Paragraph is a kind of division which has label 'p'.
@@ -70,7 +70,6 @@ class Doc < ActiveRecord::Base
 		:after_remove => [:decrement_docs_projects_counter, :queue_es_project_remove]
 	belongs_to :medium, optional: true
 
-	before_validation :resolve_medium_from_source
 	validate :media_reference_immutable, on: :update
 
 	validates :body,     presence: true
@@ -1128,21 +1127,6 @@ class Doc < ActiveRecord::Base
 		asciitext.gsub!('==amp==', '&')
 
 		asciitext
-	end
-
-	def resolve_medium_from_source
-		return unless media_sourcedb.present? && media_sourceid.present?
-		return if medium_id.present?
-
-		resolved = Medium.find_by(sourcedb: media_sourcedb, sourceid: media_sourceid)
-		if resolved
-			self.medium = resolved
-			self.media_sourcedb = nil
-			self.media_sourceid = nil
-		else
-			errors.add(:base, 'Specified media does not exist')
-			throw :abort
-		end
 	end
 
 	def media_reference_immutable

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -70,6 +70,7 @@ class Doc < ActiveRecord::Base
 		:after_remove => [:decrement_docs_projects_counter, :queue_es_project_remove]
 
 	validate :media_must_exist, if: -> { media_sourcedb.present? && media_sourceid.present? }
+	validate :media_reference_immutable, on: :update
 
 	validates :body,     presence: true
 	validates :sourcedb, presence: true
@@ -1136,6 +1137,12 @@ class Doc < ActiveRecord::Base
 	def media_must_exist
 		unless Medium.exists?(sourcedb: media_sourcedb, sourceid: media_sourceid)
 			errors.add(:base, 'Specified media does not exist')
+		end
+	end
+
+	def media_reference_immutable
+		if will_save_change_to_media_sourcedb? || will_save_change_to_media_sourceid?
+			errors.add(:base, 'Media reference cannot be changed after creation')
 		end
 	end
 end

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -69,6 +69,8 @@ class Doc < ActiveRecord::Base
 		:after_add => [:increment_docs_projects_counter, :queue_es_project_add],
 		:after_remove => [:decrement_docs_projects_counter, :queue_es_project_remove]
 
+	validate :media_must_exist, if: -> { media_sourcedb.present? && media_sourceid.present? }
+
 	validates :body,     presence: true
 	validates :sourcedb, presence: true
 	validates :sourceid, presence: true
@@ -1066,6 +1068,11 @@ class Doc < ActiveRecord::Base
 
 	def update_all_references_in_sentences = sentences.each { _1.update_references denotations }
 
+	def media
+		return nil unless media_sourcedb.present? && media_sourceid.present?
+		Medium.find_by(sourcedb: media_sourcedb, sourceid: media_sourceid)
+	end
+
 	private
 
 	# default sort order
@@ -1124,5 +1131,11 @@ class Doc < ActiveRecord::Base
 		asciitext.gsub!('==amp==', '&')
 
 		asciitext
+	end
+
+	def media_must_exist
+		unless Medium.exists?(sourcedb: media_sourcedb, sourceid: media_sourceid)
+			errors.add(:base, 'Specified media does not exist')
+		end
 	end
 end

--- a/db/migrate/20260615070604_add_media_source_to_doc.rb
+++ b/db/migrate/20260615070604_add_media_source_to_doc.rb
@@ -1,0 +1,7 @@
+class AddMediaSourceToDoc < ActiveRecord::Migration[8.1]
+  def change
+    add_column :docs, :media_sourcedb, :string
+    add_column :docs, :media_sourceid, :string
+    add_index :docs, [:media_sourcedb, :media_sourceid]
+  end
+end

--- a/db/migrate/20260615070604_add_media_source_to_doc.rb
+++ b/db/migrate/20260615070604_add_media_source_to_doc.rb
@@ -1,7 +1,0 @@
-class AddMediaSourceToDoc < ActiveRecord::Migration[8.1]
-  def change
-    add_column :docs, :media_sourcedb, :string
-    add_column :docs, :media_sourceid, :string
-    add_index :docs, [:media_sourcedb, :media_sourceid]
-  end
-end

--- a/db/migrate/20260616015514_add_medium_id_to_doc.rb
+++ b/db/migrate/20260616015514_add_medium_id_to_doc.rb
@@ -1,0 +1,5 @@
+class AddMediumIdToDoc < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :docs, :medium, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_055138) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_070604) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -196,6 +196,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_055138) do
     t.datetime "created_at", null: false
     t.integer "denotations_num", default: 0
     t.boolean "flag", default: false, null: false
+    t.string "media_sourcedb"
+    t.string "media_sourceid"
     t.integer "modifications_num", default: 0
     t.integer "projects_num", default: 0
     t.integer "relations_num", default: 0
@@ -206,6 +208,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_055138) do
     t.string "sourceid"
     t.datetime "updated_at", null: false
     t.index ["denotations_num"], name: "index_docs_on_denotations_num"
+    t.index ["media_sourcedb", "media_sourceid"], name: "index_docs_on_media_sourcedb_and_media_sourceid"
     t.index ["projects_num"], name: "index_docs_on_projects_num"
     t.index ["serial"], name: "index_docs_on_serial"
     t.index ["sourcedb", "sourceid"], name: "index_docs_on_sourcedb_and_sourceid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_070604) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_16_015514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -196,8 +196,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_070604) do
     t.datetime "created_at", null: false
     t.integer "denotations_num", default: 0
     t.boolean "flag", default: false, null: false
-    t.string "media_sourcedb"
-    t.string "media_sourceid"
+    t.bigint "medium_id"
     t.integer "modifications_num", default: 0
     t.integer "projects_num", default: 0
     t.integer "relations_num", default: 0
@@ -208,7 +207,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_070604) do
     t.string "sourceid"
     t.datetime "updated_at", null: false
     t.index ["denotations_num"], name: "index_docs_on_denotations_num"
-    t.index ["media_sourcedb", "media_sourceid"], name: "index_docs_on_media_sourcedb_and_media_sourceid"
+    t.index ["medium_id"], name: "index_docs_on_medium_id"
     t.index ["projects_num"], name: "index_docs_on_projects_num"
     t.index ["serial"], name: "index_docs_on_serial"
     t.index ["sourcedb", "sourceid"], name: "index_docs_on_sourcedb_and_sourceid", unique: true
@@ -514,6 +513,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_070604) do
   add_foreign_key "annotation_receptions", "projects"
   add_foreign_key "attrivutes", "docs"
   add_foreign_key "batch_job_trackings", "jobs", column: "parent_job_id", on_delete: :cascade
+  add_foreign_key "docs", "media"
   add_foreign_key "paragraph_attrivutes", "attrivutes"
   add_foreign_key "paragraph_attrivutes", "divisions"
   add_foreign_key "paragraph_denotations", "denotations"

--- a/spec/models/doc/media_spec.rb
+++ b/spec/models/doc/media_spec.rb
@@ -32,5 +32,21 @@ RSpec.describe Doc, type: :model do
       expect(doc).not_to be_valid
       expect(doc.errors[:base]).to include('Specified media does not exist')
     end
+
+    it 'cannot change media_sourcedb after creation' do
+      medium = create(:medium)
+      doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
+      doc.media_sourcedb = 'OtherDB'
+      expect(doc).not_to be_valid
+      expect(doc.errors[:base]).to include('Media reference cannot be changed after creation')
+    end
+
+    it 'cannot change media_sourceid after creation' do
+      medium = create(:medium)
+      doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
+      doc.media_sourceid = 'other-id'
+      expect(doc).not_to be_valid
+      expect(doc.errors[:base]).to include('Media reference cannot be changed after creation')
+    end
   end
 end

--- a/spec/models/doc/media_spec.rb
+++ b/spec/models/doc/media_spec.rb
@@ -23,32 +23,6 @@ RSpec.describe Doc, type: :model do
     end
   end
 
-  describe 'media resolution' do
-    context 'without medium' do
-      let(:medium) { nil }
-
-      it 'is valid' do
-        expect(doc).to be_valid
-      end
-    end
-
-    context 'when specifying medium by sourcedb/sourceid' do
-      let(:medium) { nil }
-
-      it 'resolves medium_id from media_sourcedb/media_sourceid before save' do
-        resolved = create(:medium)
-        doc = create(:doc, media_sourcedb: resolved.sourcedb, media_sourceid: resolved.sourceid)
-        expect(doc.medium_id).to eq(resolved.id)
-      end
-
-      it 'is invalid when the specified media does not exist' do
-        doc = build(:doc, media_sourcedb: 'NonExistDB', media_sourceid: 'no-such-id')
-        expect(doc).not_to be_valid
-        expect(doc.errors[:base]).to include('Specified media does not exist')
-      end
-    end
-  end
-
   describe 'medium_id immutability' do
     context 'with medium' do
       let(:medium) { create(:medium, sourcedb: 'DB1', sourceid: 'id1') }

--- a/spec/models/doc/media_spec.rb
+++ b/spec/models/doc/media_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Doc, type: :model do
+  describe '#media' do
+    let(:medium) { create(:medium, sourcedb: 'MediaDB', sourceid: 'img-001') }
+
+    it 'returns the associated Medium' do
+      doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
+      expect(doc.media).to eq(medium)
+    end
+
+    it 'returns nil when media_sourcedb is not set' do
+      doc = create(:doc, media_sourcedb: nil, media_sourceid: nil)
+      expect(doc.media).to be_nil
+    end
+  end
+
+  describe 'media validation' do
+    it 'is valid when media is not specified' do
+      expect(build(:doc, media_sourcedb: nil, media_sourceid: nil)).to be_valid
+    end
+
+    it 'is valid when the specified media exists' do
+      medium = create(:medium)
+      expect(build(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)).to be_valid
+    end
+
+    it 'is invalid when the specified media does not exist' do
+      doc = build(:doc, media_sourcedb: 'NonExistDB', media_sourceid: 'no-such-id')
+      expect(doc).not_to be_valid
+      expect(doc.errors[:base]).to include('Specified media does not exist')
+    end
+  end
+end

--- a/spec/models/doc/media_spec.rb
+++ b/spec/models/doc/media_spec.rb
@@ -3,46 +3,62 @@
 require 'rails_helper'
 
 RSpec.describe Doc, type: :model do
-  describe 'medium association' do
-    let(:medium) { create(:medium, sourcedb: 'MediaDB', sourceid: 'img-001') }
+  let(:doc) { create(:doc, medium: medium) }
 
-    it 'returns the associated Medium via belongs_to' do
-      doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
-      expect(doc.medium).to eq(medium)
+  describe 'medium association' do
+    context 'with medium' do
+      let(:medium) { create(:medium) }
+
+      it 'returns the associated Medium via belongs_to' do
+        expect(doc.medium).to eq(medium)
+      end
     end
 
-    it 'medium is nil when media_sourcedb/media_sourceid are not set' do
-      doc = create(:doc)
-      expect(doc.medium).to be_nil
+    context 'without medium' do
+      let(:medium) { nil }
+
+      it 'medium is nil' do
+        expect(doc.medium).to be_nil
+      end
     end
   end
 
   describe 'media resolution' do
-    it 'is valid when media is not specified' do
-      expect(build(:doc)).to be_valid
+    context 'without medium' do
+      let(:medium) { nil }
+
+      it 'is valid' do
+        expect(doc).to be_valid
+      end
     end
 
-    it 'resolves medium_id from media_sourcedb/media_sourceid before save' do
-      medium = create(:medium)
-      doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
-      expect(doc.medium_id).to eq(medium.id)
-    end
+    context 'when specifying medium by sourcedb/sourceid' do
+      let(:medium) { nil }
 
-    it 'is invalid when the specified media does not exist' do
-      doc = build(:doc, media_sourcedb: 'NonExistDB', media_sourceid: 'no-such-id')
-      expect(doc).not_to be_valid
-      expect(doc.errors[:base]).to include('Specified media does not exist')
+      it 'resolves medium_id from media_sourcedb/media_sourceid before save' do
+        resolved = create(:medium)
+        doc = create(:doc, media_sourcedb: resolved.sourcedb, media_sourceid: resolved.sourceid)
+        expect(doc.medium_id).to eq(resolved.id)
+      end
+
+      it 'is invalid when the specified media does not exist' do
+        doc = build(:doc, media_sourcedb: 'NonExistDB', media_sourceid: 'no-such-id')
+        expect(doc).not_to be_valid
+        expect(doc.errors[:base]).to include('Specified media does not exist')
+      end
     end
   end
 
   describe 'medium_id immutability' do
-    it 'cannot change medium after creation' do
-      medium1 = create(:medium, sourcedb: 'DB1', sourceid: 'id1')
-      medium2 = create(:medium, sourcedb: 'DB2', sourceid: 'id2')
-      doc = create(:doc, media_sourcedb: medium1.sourcedb, media_sourceid: medium1.sourceid)
-      doc.medium = medium2
-      expect(doc).not_to be_valid
-      expect(doc.errors[:base]).to include('Media reference cannot be changed after creation')
+    context 'with medium' do
+      let(:medium) { create(:medium, sourcedb: 'DB1', sourceid: 'id1') }
+
+      it 'cannot change medium after creation' do
+        other_medium = create(:medium, sourcedb: 'DB2', sourceid: 'id2')
+        doc.medium = other_medium
+        expect(doc).not_to be_valid
+        expect(doc.errors[:base]).to include('Media reference cannot be changed after creation')
+      end
     end
   end
 end

--- a/spec/models/doc/media_spec.rb
+++ b/spec/models/doc/media_spec.rb
@@ -3,33 +3,38 @@
 require 'rails_helper'
 
 RSpec.describe Doc, type: :model do
-  let(:doc) { create(:doc, medium: medium) }
+  subject(:doc) { create(:doc, medium: medium) }
 
-  describe 'medium association' do
-    context 'with medium' do
-      let(:medium) { create(:medium) }
+  context 'with medium' do
+    let(:medium) { create(:medium) }
 
-      it 'returns the associated Medium via belongs_to' do
-        expect(doc.medium).to eq(medium)
-      end
+    describe 'medium association' do
+      it { is_expected.to have_attributes(medium: medium) }
     end
 
-    context 'without medium' do
-      let(:medium) { nil }
+    describe 'medium_id immutability' do
+      it 'cannot change medium after creation' do
+        other_medium = create(:medium, sourcedb: 'DB2', sourceid: 'id2')
+        doc.medium = other_medium
 
-      it 'medium is nil' do
-        expect(doc.medium).to be_nil
+        expect(doc).not_to be_valid
+        expect(doc.errors[:base]).to include('Media reference cannot be changed after creation')
       end
     end
   end
 
-  describe 'medium_id immutability' do
-    context 'with medium' do
-      let(:medium) { create(:medium, sourcedb: 'DB1', sourceid: 'id1') }
+  context 'without medium' do
+    let(:medium) { nil }
 
-      it 'cannot change medium after creation' do
-        other_medium = create(:medium, sourcedb: 'DB2', sourceid: 'id2')
-        doc.medium = other_medium
+    describe 'medium association' do
+      it { is_expected.to have_attributes(medium: nil) }
+    end
+
+    describe 'medium_id immutability' do
+      it 'cannot add medium after creation' do
+        new_medium = create(:medium)
+        doc.medium = new_medium
+
         expect(doc).not_to be_valid
         expect(doc.errors[:base]).to include('Media reference cannot be changed after creation')
       end

--- a/spec/models/doc/media_spec.rb
+++ b/spec/models/doc/media_spec.rb
@@ -3,28 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Doc, type: :model do
-  describe '#media' do
+  describe 'medium association' do
     let(:medium) { create(:medium, sourcedb: 'MediaDB', sourceid: 'img-001') }
 
-    it 'returns the associated Medium' do
+    it 'returns the associated Medium via belongs_to' do
       doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
-      expect(doc.media).to eq(medium)
+      expect(doc.medium).to eq(medium)
     end
 
-    it 'returns nil when media_sourcedb is not set' do
-      doc = create(:doc, media_sourcedb: nil, media_sourceid: nil)
-      expect(doc.media).to be_nil
+    it 'medium is nil when media_sourcedb/media_sourceid are not set' do
+      doc = create(:doc)
+      expect(doc.medium).to be_nil
     end
   end
 
-  describe 'media validation' do
+  describe 'media resolution' do
     it 'is valid when media is not specified' do
-      expect(build(:doc, media_sourcedb: nil, media_sourceid: nil)).to be_valid
+      expect(build(:doc)).to be_valid
     end
 
-    it 'is valid when the specified media exists' do
+    it 'resolves medium_id from media_sourcedb/media_sourceid before save' do
       medium = create(:medium)
-      expect(build(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)).to be_valid
+      doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
+      expect(doc.medium_id).to eq(medium.id)
     end
 
     it 'is invalid when the specified media does not exist' do
@@ -32,19 +33,14 @@ RSpec.describe Doc, type: :model do
       expect(doc).not_to be_valid
       expect(doc.errors[:base]).to include('Specified media does not exist')
     end
+  end
 
-    it 'cannot change media_sourcedb after creation' do
-      medium = create(:medium)
-      doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
-      doc.media_sourcedb = 'OtherDB'
-      expect(doc).not_to be_valid
-      expect(doc.errors[:base]).to include('Media reference cannot be changed after creation')
-    end
-
-    it 'cannot change media_sourceid after creation' do
-      medium = create(:medium)
-      doc = create(:doc, media_sourcedb: medium.sourcedb, media_sourceid: medium.sourceid)
-      doc.media_sourceid = 'other-id'
+  describe 'medium_id immutability' do
+    it 'cannot change medium after creation' do
+      medium1 = create(:medium, sourcedb: 'DB1', sourceid: 'id1')
+      medium2 = create(:medium, sourcedb: 'DB2', sourceid: 'id2')
+      doc = create(:doc, media_sourcedb: medium1.sourcedb, media_sourceid: medium1.sourceid)
+      doc.medium = medium2
       expect(doc).not_to be_valid
       expect(doc.errors[:base]).to include('Media reference cannot be changed after creation')
     end


### PR DESCRIPTION
## 概要

- Docに`media_sourcedb`および`media_sourceid` カラムを追加
- Doc モデルへの Media 参照対応
  - Doc 作成時に指定された Media が存在しない場合はバリデーションエラー
  - Doc 作成後の media 参照変更を禁止
- specの追加

## 動作確認

追加分を含むspecがパスすること