### PR TITLE
Add media index and show

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,5 +1,13 @@
 class MediaController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_medium, only: [:show]
+
+  def index
+    @media_grid = initialize_grid(Medium, order: 'media.created_at', order_direction: 'desc')
+  end
+
+  def show
+  end
 
   def new
     @medium = Medium.new
@@ -17,6 +25,10 @@ class MediaController < ApplicationController
   end
 
   private
+
+  def set_medium
+    @medium = Medium.find(params[:id])
+  end
 
   def medium_params
     params.expect(medium: [:sourcedb, :sourceid, :media_type, :file])

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -27,7 +27,7 @@ class MediaController < ApplicationController
   private
 
   def set_medium
-    @medium = Medium.find(params[:id])
+    @medium = Medium.find_by!(sourcedb: params[:sourcedb], sourceid: params[:sourceid])
   end
 
   def medium_params

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -1,0 +1,31 @@
+<% content_for :path do -%>
+	> <%= link_to t('views.paths.home'), home_path -%>
+	> Media
+<% end -%>
+
+<section>
+<h1>
+	Media
+	<%= button :create, new_medium_path, 'Upload Media' %>
+</h1>
+
+<%= grid(@media_grid) do |g|
+
+	g.column name: 'Source DB', attribute: 'sourcedb' do |medium|
+		medium.sourcedb
+	end
+
+	g.column name: 'Source ID', attribute: 'sourceid' do |medium|
+		[link_to(medium.sourceid, medium_path(medium), style: 'display:block'), {title: medium.sourceid}]
+	end
+
+	g.column name: 'Type', attribute: 'media_type', filter: false do |medium|
+		[medium.media_type, {style: 'text-align:center'}]
+	end
+
+	g.column name: 'Uploaded At', attribute: 'created_at', filter: false do |medium|
+		[medium.created_at.strftime('%Y-%m-%d'), {style: 'text-align:center'}]
+	end
+
+end -%>
+</section>

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -16,7 +16,7 @@
 	end
 
 	g.column name: 'Source ID', attribute: 'sourceid' do |medium|
-		[link_to(medium.sourceid, medium_path(medium), style: 'display:block'), {title: medium.sourceid}]
+		[link_to(medium.sourceid, show_media_path(sourcedb: medium.sourcedb, sourceid: medium.sourceid), style: 'display:block'), {title: medium.sourceid}]
 	end
 
 	g.column name: 'Type', attribute: 'media_type', filter: false do |medium|

--- a/app/views/media/show.html.erb
+++ b/app/views/media/show.html.erb
@@ -1,0 +1,38 @@
+<% content_for :path do -%>
+	> <%= link_to t('views.paths.home'), home_path -%>
+	> <%= link_to 'Media', media_path %>
+	> <%= @medium.sourceid %>
+<% end -%>
+
+<section>
+	<h2><%= @medium.sourcedb %>:<%= @medium.sourceid %></h2>
+
+	<% if @medium.file.attached? %>
+		<% if @medium.image? %>
+			<%= image_tag url_for(@medium.file), style: 'max-width: 100%' %>
+		<% end %>
+	<% end %>
+
+	<table>
+		<tr>
+			<th>Source DB</th>
+			<td><%= @medium.sourcedb %></td>
+		</tr>
+		<tr>
+			<th>Source ID</th>
+			<td><%= @medium.sourceid %></td>
+		</tr>
+		<tr>
+			<th>Media Type</th>
+			<td><%= @medium.media_type %></td>
+		</tr>
+		<tr>
+			<th>Content Type</th>
+			<td><%= @medium.content_type %></td>
+		</tr>
+		<tr>
+			<th>Uploaded At</th>
+			<td><%= @medium.created_at.strftime('%Y-%m-%d %H:%M') %></td>
+		</tr>
+	</table>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Pubann::Application.routes.draw do
     end
   end
 
-	resources :media, only: [:index, :new, :create, :show]
+	resources :media, only: [:index, :new, :create] do
+		collection do
+			get 'sourcedbs/:sourcedb/sourceids/:sourceid', to: 'media#show', as: :show
+		end
+	end
 
 	resources :evaluators
 	resources :evaluations do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Pubann::Application.routes.draw do
     end
   end
 
-	resources :media, only: [:new, :create]
+	resources :media, only: [:index, :new, :create, :show]
 
 	resources :evaluators
 	resources :evaluations do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -32,20 +32,20 @@ RSpec.describe 'MediaController', type: :request do
     end
   end
 
-  describe 'GET /media/:id' do
+  describe 'GET /media/sourcedbs/:sourcedb/sourceids/:sourceid' do
     let(:medium) { create(:medium) }
 
     context 'when logged in' do
       it 'renders the show page' do
         sign_in user
-        get medium_path(medium)
+        get show_media_path(sourcedb: medium.sourcedb, sourceid: medium.sourceid)
         expect(response).to have_http_status(:ok)
       end
     end
 
     context 'when not logged in' do
       it 'redirects to login' do
-        get medium_path(medium)
+        get show_media_path(sourcedb: medium.sourcedb, sourceid: medium.sourceid)
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -13,6 +13,44 @@ RSpec.describe 'MediaController', type: :request do
     )
   end
 
+  describe 'GET /media' do
+    let!(:medium) { create(:medium) }
+
+    context 'when logged in' do
+      it 'renders the index' do
+        sign_in user
+        get media_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not logged in' do
+      it 'redirects to login' do
+        get media_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe 'GET /media/:id' do
+    let(:medium) { create(:medium) }
+
+    context 'when logged in' do
+      it 'renders the show page' do
+        sign_in user
+        get medium_path(medium)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not logged in' do
+      it 'redirects to login' do
+        get medium_path(medium)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
   describe 'GET /media/new' do
     context 'when logged in' do
       before { sign_in user }


### PR DESCRIPTION
## 概要

mediaの一覧と詳細画面の作成を行いました。

### 一覧画面

<img width="1161" height="449" alt="スクリーンショット 2026-06-19 9 16 12" src="https://github.com/user-attachments/assets/3e8f49f3-4d6f-4e46-973f-621bce4777ee" />


### 詳細画面

パスは`/media/sourcedbs/[sourcedb]/sourceids/[sourceid]`になっています

<img width="1122" height="862" alt="スクリーンショット 2026-06-19 9 16 26" src="https://github.com/user-attachments/assets/eb2485dd-3420-40e3-80ae-55c840869d1e" />


## 動作確認

- 追加分を含めたspecがすべてパスすることを確認
- media一覧画面( http://localhost:3000/media )が表示できることを確認
- media作成画面で作成したmediaが一覧の表示できることを確認
- media一覧から作成済みのmediaの詳細画面に遷移できることを確認
- media詳細画面が表示できることを確認