### PR TITLE
Media delete

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,4 +1,6 @@
 class MediaController < ApplicationController
+  include MediumHelper
+
   before_action :authenticate_user!
   before_action :set_medium, only: [:show, :destroy]
   before_action :authorize_destroy!, only: [:destroy]
@@ -38,7 +40,7 @@ class MediaController < ApplicationController
   end
 
   def authorize_destroy!
-    unless @medium.user == current_user
+    unless current_user_owns_medium?(@medium)
       redirect_to show_media_path(sourcedb: @medium.sourcedb, sourceid: @medium.sourceid), alert: 'You are not authorized to delete this media.'
     end
   end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,7 @@
 class MediaController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_medium, only: [:show]
+  before_action :set_medium, only: [:show, :destroy]
+  before_action :authorize_destroy!, only: [:destroy]
 
   def index
     @media_grid = initialize_grid(Medium, order: 'media.created_at', order_direction: 'desc')
@@ -15,6 +16,7 @@ class MediaController < ApplicationController
 
   def create
     @medium = Medium.new(medium_params)
+    @medium.user = current_user
     @medium.content_type = params[:medium][:file]&.content_type
 
     if @medium.save
@@ -24,10 +26,21 @@ class MediaController < ApplicationController
     end
   end
 
+  def destroy
+    @medium.destroy
+    redirect_to media_path, notice: 'Media was successfully deleted.'
+  end
+
   private
 
   def set_medium
     @medium = Medium.find_by!(sourcedb: params[:sourcedb], sourceid: params[:sourceid])
+  end
+
+  def authorize_destroy!
+    unless @medium.user == current_user
+      redirect_to show_media_path(sourcedb: @medium.sourcedb, sourceid: @medium.sourceid), alert: 'You are not authorized to delete this media.'
+    end
   end
 
   def medium_params

--- a/app/helpers/medium_helper.rb
+++ b/app/helpers/medium_helper.rb
@@ -1,0 +1,5 @@
+module MediumHelper
+  def current_user_owns_medium?(medium)
+    medium.user == current_user
+  end
+end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -2,6 +2,7 @@ class Medium < ApplicationRecord
   has_one_attached :file
 
   belongs_to :user
+  has_many :docs, dependent: :destroy
 
   enum :media_type, { image: 0, video: 1, audio: 2 }
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,6 +1,8 @@
 class Medium < ApplicationRecord
   has_one_attached :file
 
+  belongs_to :user
+
   enum :media_type, { image: 0, video: 1, audio: 2 }
 
   validates :sourcedb, presence: true

--- a/app/views/media/show.html.erb
+++ b/app/views/media/show.html.erb
@@ -36,7 +36,7 @@
 		</tr>
 	</table>
 
-	<% if current_user == @medium.user %>
+	<% if current_user_owns_medium?(@medium) %>
 		<%= button_to 'Delete', destroy_media_path(sourcedb: @medium.sourcedb, sourceid: @medium.sourceid), method: :delete, data: { confirm: 'Are you sure?' } %>
 	<% end %>
 </section>

--- a/app/views/media/show.html.erb
+++ b/app/views/media/show.html.erb
@@ -35,4 +35,8 @@
 			<td><%= @medium.created_at.strftime('%Y-%m-%d %H:%M') %></td>
 		</tr>
 	</table>
+
+	<% if current_user == @medium.user %>
+		<%= button_to 'Delete', destroy_media_path(sourcedb: @medium.sourcedb, sourceid: @medium.sourceid), method: :delete, data: { confirm: 'Are you sure?' } %>
+	<% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Pubann::Application.routes.draw do
 	resources :media, only: [:index, :new, :create] do
 		collection do
 			get 'sourcedbs/:sourcedb/sourceids/:sourceid', to: 'media#show', as: :show
+			delete 'sourcedbs/:sourcedb/sourceids/:sourceid', to: 'media#destroy', as: :destroy
 		end
 	end
 

--- a/db/migrate/20260617015809_add_user_to_media.rb
+++ b/db/migrate/20260617015809_add_user_to_media.rb
@@ -1,0 +1,5 @@
+class AddUserToMedia < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :media, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_16_015514) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_015809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -286,7 +286,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_015514) do
     t.string "sourcedb"
     t.string "sourceid"
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["sourcedb", "sourceid"], name: "index_media_on_sourcedb_and_sourceid", unique: true
+    t.index ["user_id"], name: "index_media_on_user_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -514,6 +516,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_015514) do
   add_foreign_key "attrivutes", "docs"
   add_foreign_key "batch_job_trackings", "jobs", column: "parent_job_id", on_delete: :cascade
   add_foreign_key "docs", "media"
+  add_foreign_key "media", "users"
   add_foreign_key "paragraph_attrivutes", "attrivutes"
   add_foreign_key "paragraph_attrivutes", "divisions"
   add_foreign_key "paragraph_denotations", "denotations"

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'MediaController', type: :request do
     end
   end
 
-  describe 'DELETE /media/:id' do
+  describe 'DELETE /media/sourcedbs/:sourcedb/sourceids/:sourceid' do
     let(:medium) { create(:medium, user: user) }
 
     context 'when logged in as the creator' do
@@ -118,7 +118,7 @@ RSpec.describe 'MediaController', type: :request do
       it 'deletes the medium' do
         medium
         expect {
-          delete medium_path(medium)
+          delete destroy_media_path(sourcedb: medium.sourcedb, sourceid: medium.sourceid)
         }.to change(Medium, :count).by(-1)
         expect(response).to redirect_to(media_path)
       end
@@ -132,15 +132,15 @@ RSpec.describe 'MediaController', type: :request do
 
       it 'does not delete the medium and redirects' do
         expect {
-          delete medium_path(existing_medium)
+          delete destroy_media_path(sourcedb: existing_medium.sourcedb, sourceid: existing_medium.sourceid)
         }.not_to change(Medium, :count)
-        expect(response).to redirect_to(medium_path(existing_medium))
+        expect(response).to redirect_to(show_media_path(sourcedb: existing_medium.sourcedb, sourceid: existing_medium.sourceid))
       end
     end
 
     context 'when not logged in' do
       it 'redirects to login' do
-        delete medium_path(medium)
+        delete destroy_media_path(sourcedb: medium.sourcedb, sourceid: medium.sourceid)
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -108,4 +108,41 @@ RSpec.describe 'MediaController', type: :request do
       end
     end
   end
+
+  describe 'DELETE /media/:id' do
+    let(:medium) { create(:medium, user: user) }
+
+    context 'when logged in as the creator' do
+      before { sign_in user }
+
+      it 'deletes the medium' do
+        medium
+        expect {
+          delete medium_path(medium)
+        }.to change(Medium, :count).by(-1)
+        expect(response).to redirect_to(media_path)
+      end
+    end
+
+    context 'when logged in as a different user' do
+      let(:other_user) { create(:user).tap { |u| u.confirm } }
+      let!(:existing_medium) { medium }
+
+      before { sign_in other_user }
+
+      it 'does not delete the medium and redirects' do
+        expect {
+          delete medium_path(existing_medium)
+        }.not_to change(Medium, :count)
+        expect(response).to redirect_to(medium_path(existing_medium))
+      end
+    end
+
+    context 'when not logged in' do
+      it 'redirects to login' do
+        delete medium_path(medium)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end

--- a/spec/factories/media.rb
+++ b/spec/factories/media.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     sequence(:sourceid) { |n| "media_#{n}" }
     media_type { :image }
     content_type { 'image/jpeg' }
+    association :user
   end
 end

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -46,4 +46,12 @@ RSpec.describe Medium, type: :model do
       expect(Medium.new).to respond_to(:file)
     end
   end
+
+  describe 'dependent destroy' do
+    it 'destroys associated docs when medium is deleted' do
+      medium = create(:medium)
+      create(:doc, medium: medium)
+      expect { medium.destroy }.to change(Doc, :count).by(-1)
+    end
+  end
 end


### PR DESCRIPTION
## 概要

- mediaの削除機能の実装を行いました。

<img width="638" height="282" alt="スクリーンショット 2026-06-19 10 24 19" src="https://github.com/user-attachments/assets/6a589aeb-41f8-4b99-9377-d184ce6b4710" />

- mediaに作成したuserを保存するカラムを追加しました。
  - 削除を実行できるユーザーを絞るため
  - お手数おかけしますが、マイグレーション実行前に既存のmediaの削除をお願いいたします。

```
% bin/rails console
```
```
Medium.all.delete_all
```

- 削除機能に関するspecを追加しました。

## 動作確認

- 追加分を含むすべてのspecがパスすることを確認
- ブラウザ経由で作成したmediaを削除できることを確認
- 別のユーザーとしてログインした時、media詳細画面に削除ボタンが表示されていないことを確認