### PR TITLE
Media bulk upload

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -30,9 +30,6 @@ class MediaController < ApplicationController
 
   def bulk_upload
     zip_file = bulk_upload_params
-    unless zip_file.present?
-      redirect_to new_medium_path, alert: 'Please select a ZIP file.' and return
-    end
 
     service = MediumBulkUploadService.new(zip_file, current_user)
     service.call
@@ -50,7 +47,7 @@ class MediaController < ApplicationController
   private
 
   def bulk_upload_params
-    params.permit(:zip_file)[:zip_file]
+    params.expect(:zip_file)
   end
 
   def set_medium

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -28,6 +28,22 @@ class MediaController < ApplicationController
     end
   end
 
+  def bulk_upload
+    zip_file = params[:zip_file]
+    unless zip_file.present?
+      redirect_to new_medium_path, alert: 'Please select a ZIP file.' and return
+    end
+
+    service = MediumBulkUploadService.new(zip_file, current_user)
+    service.call
+
+    notice = "#{service.successes.size} file(s) uploaded successfully."
+    notice += " #{service.errors.size} file(s) failed: #{service.errors.join(' / ')}" if service.errors.any?
+    redirect_to media_path, notice: notice
+  rescue ArgumentError => e
+    redirect_to new_medium_path, alert: e.message
+  end
+
   def destroy
     @medium.destroy
     redirect_to media_path, notice: 'Media was successfully deleted.'

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -29,7 +29,7 @@ class MediaController < ApplicationController
   end
 
   def bulk_upload
-    zip_file = params[:zip_file]
+    zip_file = bulk_upload_params
     unless zip_file.present?
       redirect_to new_medium_path, alert: 'Please select a ZIP file.' and return
     end
@@ -37,9 +37,7 @@ class MediaController < ApplicationController
     service = MediumBulkUploadService.new(zip_file, current_user)
     service.call
 
-    notice = "#{service.successes.size} file(s) uploaded successfully."
-    notice += " #{service.errors.size} file(s) failed: #{service.errors.join(' / ')}" if service.errors.any?
-    redirect_to media_path, notice: notice
+    redirect_to media_path, notice: service.result_message
   rescue ArgumentError => e
     redirect_to new_medium_path, alert: e.message
   end
@@ -50,6 +48,10 @@ class MediaController < ApplicationController
   end
 
   private
+
+  def bulk_upload_params
+    params.expect(:zip_file)
+  end
 
   def set_medium
     @medium = Medium.find_by!(sourcedb: params[:sourcedb], sourceid: params[:sourceid])

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -50,7 +50,7 @@ class MediaController < ApplicationController
   private
 
   def bulk_upload_params
-    params.expect(:zip_file)
+    params.permit(:zip_file)[:zip_file]
   end
 
   def set_medium

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -10,4 +10,11 @@ class Medium < ApplicationRecord
   validates :sourceid, presence: true, uniqueness: { scope: :sourcedb }
   validates :media_type, presence: true
   validates :content_type, presence: true
+
+  def self.create_with_file(attributes, io:, filename:, content_type:)
+    medium = new(attributes)
+    medium.file.attach(io: io, filename: filename, content_type: content_type)
+    medium.save
+    medium
+  end
 end

--- a/app/services/medium_bulk_upload_service.rb
+++ b/app/services/medium_bulk_upload_service.rb
@@ -7,8 +7,6 @@ class MediumBulkUploadService
     '.webp' => [:image, 'image/webp']
   }.freeze
 
-  attr_reader :successes, :errors
-
   def initialize(zip_file, user)
     @zip_file = zip_file
     @user = user
@@ -27,19 +25,23 @@ class MediumBulkUploadService
   end
 
   def result_message
-    message = "#{successes.size} file(s) uploaded successfully."
-    message += " #{errors.size} file(s) failed: #{errors.join(' / ')}" if errors.any?
+    message = "#{@successes.size} file(s) uploaded successfully."
+    message += " #{@errors.size} file(s) failed: #{@errors.join(' / ')}" if @errors.any?
     message
   end
 
   private
 
-  def process_entry(entry)
-    return if entry.directory?
-
+  def skippable_entry?(entry)
     filename = File.basename(entry.name)
-    return if filename.start_with?('.') || entry.name.start_with?('__MACOSX/')
 
+    entry.directory? ||
+      filename.start_with?('.') ||
+      entry.name.start_with?('__MACOSX/')
+  end
+
+  def validate_entry(entry)
+    filename = File.basename(entry.name)
     ext = File.extname(filename).downcase
 
     unless ext.present?
@@ -53,6 +55,7 @@ class MediumBulkUploadService
     end
 
     basename = File.basename(filename, ext)
+
     unless basename.match?(/\A[^\s-]+-[^\s-]+\z/)
       @errors << "#{filename}: filename must be in 'sourcedb-sourceid#{ext}' format (one hyphen, no spaces), skipped."
       return
@@ -61,25 +64,46 @@ class MediumBulkUploadService
     sourcedb, sourceid = basename.split('-', 2)
     media_type, content_type = EXTENSION_TO_MEDIA_TYPE[ext]
 
-    medium = Medium.new(
-      sourcedb: sourcedb,
-      sourceid: sourceid,
-      media_type: media_type,
-      content_type: content_type,
-      user: @user
-    )
+    {
+      filename:,
+      ext:,
+      sourcedb:,
+      sourceid:,
+      media_type:,
+      content_type:
+    }
+  end
 
-    Tempfile.create(["media-upload-", ext]) do |tmp|
+  def process_entry(entry)
+    return if skippable_entry?(entry)
+
+    attributes = validate_entry(entry)
+    return unless attributes
+
+    Tempfile.create(["media-upload-", attributes[:ext]]) do |tmp|
       input = entry.get_input_stream
       begin
         IO.copy_stream(input, tmp)
         tmp.flush
         tmp.rewind
-        medium.file.attach(io: tmp, filename: filename, content_type: content_type)
-        if medium.save
-          @successes << filename
+
+        medium = Medium.create_with_file(
+          {
+            sourcedb: attributes[:sourcedb],
+            sourceid: attributes[:sourceid],
+            media_type: attributes[:media_type],
+            content_type: attributes[:content_type],
+            user: @user
+          },
+          io: tmp,
+          filename: attributes[:filename],
+          content_type: attributes[:content_type]
+        )
+
+        if medium.persisted?
+          @successes << attributes[:filename]
         else
-          @errors << "#{filename}: #{medium.errors.full_messages.join(', ')}"
+          @errors << "#{attributes[:filename]}: #{medium.errors.full_messages.join(', ')}"
         end
       ensure
         input.close

--- a/app/services/medium_bulk_upload_service.rb
+++ b/app/services/medium_bulk_upload_service.rb
@@ -1,0 +1,79 @@
+class MediumBulkUploadService
+  EXTENSION_TO_MEDIA_TYPE = {
+    '.jpg' => [:image, 'image/jpeg'],
+    '.jpeg' => [:image, 'image/jpeg'],
+    '.png' => [:image, 'image/png'],
+    '.gif' => [:image, 'image/gif'],
+    '.webp' => [:image, 'image/webp']
+  }.freeze
+
+  attr_reader :successes, :errors
+
+  def initialize(zip_file, user)
+    @zip_file = zip_file
+    @user = user
+    @successes = []
+    @errors = []
+  end
+
+  def call
+    Zip::File.open(@zip_file.path) do |zip|
+      zip.each do |entry|
+        process_entry(entry)
+      end
+    end
+  rescue Zip::Error => e
+    raise ArgumentError, "Invalid ZIP file: #{e.message}"
+  end
+
+  private
+
+  def process_entry(entry)
+    return if entry.directory?
+
+    filename = File.basename(entry.name)
+    return if filename.start_with?('.') || entry.name.start_with?('__MACOSX/')
+
+    ext = File.extname(filename).downcase
+
+    unless ext.present?
+      @errors << "#{filename}: no extension, skipped."
+      return
+    end
+
+    unless EXTENSION_TO_MEDIA_TYPE.key?(ext)
+      @errors << "#{filename}: unsupported extension '#{ext}', skipped."
+      return
+    end
+
+    basename = File.basename(filename, ext)
+    unless basename.match?(/\A[^\s-]+-[^\s-]+\z/)
+      @errors << "#{filename}: filename must be in 'sourcedb-sourceid#{ext}' format (one hyphen, no spaces), skipped."
+      return
+    end
+
+    sourcedb, sourceid = basename.split('-', 2)
+    media_type, content_type = EXTENSION_TO_MEDIA_TYPE[ext]
+
+    medium = Medium.new(
+      sourcedb: sourcedb,
+      sourceid: sourceid,
+      media_type: media_type,
+      content_type: content_type,
+      user: @user
+    )
+
+    Tempfile.create([basename, ext]) do |tmp|
+      tmp.binmode
+      tmp.write(entry.get_input_stream.read)
+      tmp.flush
+      medium.file.attach(io: File.open(tmp.path), filename: filename, content_type: content_type)
+    end
+
+    if medium.save
+      @successes << filename
+    else
+      @errors << "#{filename}: #{medium.errors.full_messages.join(', ')}"
+    end
+  end
+end

--- a/app/services/medium_bulk_upload_service.rb
+++ b/app/services/medium_bulk_upload_service.rb
@@ -26,6 +26,12 @@ class MediumBulkUploadService
     raise ArgumentError, "Invalid ZIP file: #{e.message}"
   end
 
+  def result_message
+    message = "#{successes.size} file(s) uploaded successfully."
+    message += " #{errors.size} file(s) failed: #{errors.join(' / ')}" if errors.any?
+    message
+  end
+
   private
 
   def process_entry(entry)

--- a/app/services/medium_bulk_upload_service.rb
+++ b/app/services/medium_bulk_upload_service.rb
@@ -63,12 +63,11 @@ class MediumBulkUploadService
       user: @user
     )
 
-    Tempfile.create([basename, ext]) do |tmp|
-      tmp.binmode
-      tmp.write(entry.get_input_stream.read)
-      tmp.flush
-      medium.file.attach(io: File.open(tmp.path), filename: filename, content_type: content_type)
-    end
+    medium.file.attach(
+      io: StringIO.new(entry.get_input_stream.read),
+      filename: filename,
+      content_type: content_type
+    )
 
     if medium.save
       @successes << filename

--- a/app/services/medium_bulk_upload_service.rb
+++ b/app/services/medium_bulk_upload_service.rb
@@ -63,16 +63,24 @@ class MediumBulkUploadService
       user: @user
     )
 
-    medium.file.attach(
-      io: StringIO.new(entry.get_input_stream.read),
-      filename: filename,
-      content_type: content_type
-    )
+    tmp = Tempfile.new(["media-upload-", ext])
+    input = entry.get_input_stream
+    begin
+      IO.copy_stream(input, tmp)
+      tmp.flush
+      tmp.rewind
+      medium.file.attach(io: tmp, filename: filename, content_type: content_type)
+    ensure
+      input.close
+    end
 
     if medium.save
       @successes << filename
     else
       @errors << "#{filename}: #{medium.errors.full_messages.join(', ')}"
     end
+  ensure
+    tmp&.close
+    tmp&.unlink
   end
 end

--- a/app/services/medium_bulk_upload_service.rb
+++ b/app/services/medium_bulk_upload_service.rb
@@ -63,24 +63,21 @@ class MediumBulkUploadService
       user: @user
     )
 
-    tmp = Tempfile.new(["media-upload-", ext])
-    input = entry.get_input_stream
-    begin
-      IO.copy_stream(input, tmp)
-      tmp.flush
-      tmp.rewind
-      medium.file.attach(io: tmp, filename: filename, content_type: content_type)
-    ensure
-      input.close
+    Tempfile.create(["media-upload-", ext]) do |tmp|
+      input = entry.get_input_stream
+      begin
+        IO.copy_stream(input, tmp)
+        tmp.flush
+        tmp.rewind
+        medium.file.attach(io: tmp, filename: filename, content_type: content_type)
+        if medium.save
+          @successes << filename
+        else
+          @errors << "#{filename}: #{medium.errors.full_messages.join(', ')}"
+        end
+      ensure
+        input.close
+      end
     end
-
-    if medium.save
-      @successes << filename
-    else
-      @errors << "#{filename}: #{medium.errors.full_messages.join(', ')}"
-    end
-  ensure
-    tmp&.close
-    tmp&.unlink
   end
 end

--- a/app/views/media/_bulk_upload_form.html.erb
+++ b/app/views/media/_bulk_upload_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_tag bulk_upload_media_path, multipart: true do %>
+	<table>
+		<tr>
+			<th><label>ZIP file</label></th>
+			<td><%= file_field_tag :zip_file, accept: '.zip' %></td>
+		</tr>
+		<tr>
+			<th></th>
+			<td><%= submit_tag 'Upload ZIP' %></td>
+		</tr>
+	</table>
+<% end %>

--- a/app/views/media/_bulk_upload_form.html.erb
+++ b/app/views/media/_bulk_upload_form.html.erb
@@ -2,7 +2,7 @@
 	<table>
 		<tr>
 			<th><label>ZIP file</label></th>
-			<td><%= file_field_tag :zip_file, accept: '.zip' %></td>
+			<td><%= file_field_tag :zip_file, accept: '.zip', required: true %></td>
 		</tr>
 		<tr>
 			<th></th>

--- a/app/views/media/_form.html.erb
+++ b/app/views/media/_form.html.erb
@@ -10,16 +10,16 @@
 	<table>
 		<tr>
 			<th><%= f.label :sourcedb, 'Source DB' %></th>
-			<td><%= f.text_field :sourcedb %></td>
+			<td><%= f.text_field :sourcedb, required: true %></td>
 		</tr>
 		<tr>
 			<th><%= f.label :sourceid, 'Source ID' %></th>
-			<td><%= f.text_field :sourceid %></td>
+			<td><%= f.text_field :sourceid, required: true %></td>
 		</tr>
 		<%= f.hidden_field :media_type, value: :image %>
 		<tr>
 			<th><%= f.label :file, 'File' %></th>
-			<td><%= f.file_field :file, accept: 'image/*' %></td>
+			<td><%= f.file_field :file, accept: 'image/*', required: true %></td>
 		</tr>
 		<tr>
 			<th></th>

--- a/app/views/media/new.html.erb
+++ b/app/views/media/new.html.erb
@@ -5,6 +5,16 @@
 <% end -%>
 
 <section>
-	<h2>Upload Media</h2>
+	<h2>Upload a single media file</h2>
 	<%= render 'form' %>
+</section>
+
+<section>
+	<h2>Bulk upload via ZIP</h2>
+	<ul>
+		<li>Upload a ZIP file containing multiple media files.</li>
+		<li>Each filename must be in the form <i>sourcedb-sourceid.ext</i> (e.g. PMC-12345.jpg).</li>
+		<li>Files without an extension will be skipped.</li>
+	</ul>
+	<%= render 'bulk_upload_form' %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Pubann::Application.routes.draw do
 		collection do
 			get 'sourcedbs/:sourcedb/sourceids/:sourceid', to: 'media#show', as: :show
 			delete 'sourcedbs/:sourcedb/sourceids/:sourceid', to: 'media#destroy', as: :destroy
+			post 'bulk_upload', to: 'media#bulk_upload'
 		end
 	end
 

--- a/spec/services/medium_bulk_upload_service_spec.rb
+++ b/spec/services/medium_bulk_upload_service_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MediumBulkUploadService do
+  let(:user) { create(:user).tap { |u| u.confirm } }
+  let(:png_data) { File.binread(Rails.root.join('spec', 'fixtures', 'files', 'test_image.png')) }
+
+  def build_zip(entries)
+    Tempfile.new(['test', '.zip']).tap do |zip_file|
+      zip_file.close
+      Zip::OutputStream.open(zip_file.path) do |zip|
+        entries.each do |name, data|
+          zip.put_next_entry(name)
+          zip.write(data || '')
+        end
+      end
+    end
+  end
+
+  describe '#call' do
+    context 'with valid image files' do
+      let(:zip_file) { build_zip({ 'PMC-12345.png' => png_data }) }
+
+      it 'creates a Medium' do
+        expect {
+          described_class.new(zip_file, user).call
+        }.to change(Medium, :count).by(1)
+      end
+
+      it 'sets sourcedb and sourceid correctly' do
+        described_class.new(zip_file, user).call
+        medium = Medium.find_by(sourcedb: 'PMC', sourceid: '12345')
+        expect(medium).to be_present
+      end
+
+      it 'reports success' do
+        service = described_class.new(zip_file, user)
+        service.call
+        expect(service.successes).to include('PMC-12345.png')
+        expect(service.errors).to be_empty
+      end
+    end
+
+    context 'with macOS metadata files' do
+      let(:zip_file) do
+        build_zip({
+          '.DS_Store' => '',
+          '__MACOSX/._PMC-12345.png' => '',
+          'PMC-12345.png' => png_data
+        })
+      end
+
+      it 'skips .DS_Store and __MACOSX files' do
+        service = described_class.new(zip_file, user)
+        service.call
+        expect(Medium.count).to eq(1)
+        expect(service.successes).to eq(['PMC-12345.png'])
+      end
+    end
+
+    context 'with a file without extension' do
+      let(:zip_file) { build_zip({ 'PMC-12345' => '' }) }
+
+      it 'reports an error' do
+        service = described_class.new(zip_file, user)
+        service.call
+        expect(service.errors.first).to include('no extension')
+      end
+    end
+
+    context 'with an unsupported extension' do
+      let(:zip_file) { build_zip({ 'PMC-12345.txt' => '' }) }
+
+      it 'reports an error' do
+        service = described_class.new(zip_file, user)
+        service.call
+        expect(service.errors.first).to include('unsupported extension')
+      end
+    end
+
+    context 'with invalid filename format' do
+      it 'reports error for filename with spaces' do
+        zip_file = build_zip({ 'my file-001.png' => png_data })
+        service = described_class.new(zip_file, user)
+        service.call
+        expect(service.errors.first).to include('sourcedb-sourceid')
+      end
+
+      it 'reports error for filename with multiple hyphens' do
+        zip_file = build_zip({ 'PMC-sub-12345.png' => png_data })
+        service = described_class.new(zip_file, user)
+        service.call
+        expect(service.errors.first).to include('sourcedb-sourceid')
+      end
+
+      it 'reports error for filename without hyphen' do
+        zip_file = build_zip({ 'PMC12345.png' => png_data })
+        service = described_class.new(zip_file, user)
+        service.call
+        expect(service.errors.first).to include('sourcedb-sourceid')
+      end
+    end
+
+    context 'with an invalid ZIP file' do
+      let(:zip_file) do
+        Tempfile.new(['bad', '.zip']).tap do |f|
+          f.write('not a zip file')
+          f.close
+        end
+      end
+
+      it 'raises ArgumentError' do
+        expect {
+          described_class.new(zip_file, user).call
+        }.to raise_error(ArgumentError, /Invalid ZIP file/)
+      end
+    end
+  end
+end

--- a/spec/services/medium_bulk_upload_service_spec.rb
+++ b/spec/services/medium_bulk_upload_service_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe MediumBulkUploadService do
         expect(medium).to be_present
       end
 
-      it 'reports success' do
+      it 'reports success in result_message' do
         service = described_class.new(zip_file, user)
         service.call
-        expect(service.successes).to include('PMC-12345.png')
-        expect(service.errors).to be_empty
+        expect(service.result_message).to include('1 file(s) uploaded successfully')
+        expect(service.result_message).not_to include('failed')
       end
     end
 
@@ -55,27 +55,27 @@ RSpec.describe MediumBulkUploadService do
         service = described_class.new(zip_file, user)
         service.call
         expect(Medium.count).to eq(1)
-        expect(service.successes).to eq(['PMC-12345.png'])
+        expect(service.result_message).to include('1 file(s) uploaded successfully')
       end
     end
 
     context 'with a file without extension' do
       let(:zip_file) { build_zip({ 'PMC-12345' => '' }) }
 
-      it 'reports an error' do
+      it 'reports an error in result_message' do
         service = described_class.new(zip_file, user)
         service.call
-        expect(service.errors.first).to include('no extension')
+        expect(service.result_message).to include('no extension')
       end
     end
 
     context 'with an unsupported extension' do
       let(:zip_file) { build_zip({ 'PMC-12345.txt' => '' }) }
 
-      it 'reports an error' do
+      it 'reports an error in result_message' do
         service = described_class.new(zip_file, user)
         service.call
-        expect(service.errors.first).to include('unsupported extension')
+        expect(service.result_message).to include('unsupported extension')
       end
     end
 
@@ -84,21 +84,21 @@ RSpec.describe MediumBulkUploadService do
         zip_file = build_zip({ 'my file-001.png' => png_data })
         service = described_class.new(zip_file, user)
         service.call
-        expect(service.errors.first).to include('sourcedb-sourceid')
+        expect(service.result_message).to include('sourcedb-sourceid')
       end
 
       it 'reports error for filename with multiple hyphens' do
         zip_file = build_zip({ 'PMC-sub-12345.png' => png_data })
         service = described_class.new(zip_file, user)
         service.call
-        expect(service.errors.first).to include('sourcedb-sourceid')
+        expect(service.result_message).to include('sourcedb-sourceid')
       end
 
       it 'reports error for filename without hyphen' do
         zip_file = build_zip({ 'PMC12345.png' => png_data })
         service = described_class.new(zip_file, user)
         service.call
-        expect(service.errors.first).to include('sourcedb-sourceid')
+        expect(service.result_message).to include('sourcedb-sourceid')
       end
     end
 


### PR DESCRIPTION
## 概要

Mediaの一括アップロード機能の実装

<img width="1070" height="639" alt="スクリーンショット 2026-06-22 11 53 40" src="https://github.com/user-attachments/assets/75b10d11-b907-480f-82ec-d1fe21ec4df9" />

- media新規フォーム( http://localhost:3000/media/new )に新しいフォームを追加
- 解凍したzipファイルの直下にある画像ファイルを保存する機能を作成しました。
  - 解凍したzipファイルの画像ファイルの名称を`sourcedb-sourceid`の形式で取り出して保存
  - ファイル名がフォーマットに従っていない場合はスキップ
  - 既存のsourcedb、sourceidのファイルはスキップ


## 動作確認

- 追加分を含むすべてのspecがパスすることを確認
- ブラウザ上で動作確認

[操作手順]

http://localhost:3000/media/new の一括アップロード用フォームに以下のzipファイルをアップロード

[images.zip](https://github.com/user-attachments/files/29190045/images.zip)
zipには以下のファイルが含まれています
- `test-jpeg.jpeg`
- `test-png.png`
- `error.jpeg`

pngとjpgが保存され、エラー画像が保存されないことを確認
<img width="1027" height="609" alt="スクリーンショット 2026-06-22 13 10 34" src="https://github.com/user-attachments/assets/148c9744-6077-451b-a0d3-9673ef3fac69" />

保存された画像の詳細画面で、Content Typeが正しく保存されることを確認