### PR TITLE
Rename doc body param to text in controller, view and spec

### DIFF
--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -302,8 +302,6 @@ class DocsController < ApplicationController
 			else
 				text = if params[:text]
 					params[:text]
-				elsif params[:body]
-					params[:body]
 				elsif request.content_type =~ /text/
 					request.body.read
 				end
@@ -409,8 +407,9 @@ class DocsController < ApplicationController
 		@doc = Doc.find_by(id: params[:id])
 
 		params = doc_params
-		params[:body].gsub!(/\r\n/, "\n")
-		is_success = @doc.update(params)
+		text = params.delete(:text) || params.delete(:body)
+		text&.gsub!(/\r\n/, "\n")
+		is_success = @doc.update(params.merge(body: text))
 
 		respond_to do |format|
 			if is_success
@@ -675,7 +674,7 @@ class DocsController < ApplicationController
 	end
 
 	def doc_params
-		params.require(:doc).permit(:body, :source, :sourcedb, :sourceid, :username)
+		params.require(:doc).permit(:text, :body, :source, :sourcedb, :sourceid, :username)
 	end
 
 	def get_project2 (project_name)

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -407,7 +407,7 @@ class DocsController < ApplicationController
 		@doc = Doc.find_by(id: params[:id])
 
 		params = doc_params
-		text = params.delete(:text) || params.delete(:body)
+		text = params.delete(:text)
 		text&.gsub!(/\r\n/, "\n")
 		is_success = @doc.update(params.merge(body: text))
 

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -674,7 +674,7 @@ class DocsController < ApplicationController
 	end
 
 	def doc_params
-		params.require(:doc).permit(:text, :body, :source, :sourcedb, :sourceid, :username)
+		params.expect(doc: [:text, :source, :sourcedb, :sourceid, :username])
 	end
 
 	def get_project2 (project_name)

--- a/app/views/docs/_form.html.erb
+++ b/app/views/docs/_form.html.erb
@@ -4,7 +4,7 @@
 	<table style="width:610px">
 		<tr>
 			<th style="width:5em">Text</th>
-			<td><%= f.text_area :body, size:"60x10" %></td>
+			<td><%= text_area_tag 'doc[text]', @doc.body, size: "60x10" %></td>
 		</tr>
 		<tr>
 			<th>Meta-data</th>

--- a/spec/requests/docs_create_with_media_spec.rb
+++ b/spec/requests/docs_create_with_media_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'POST /docs.json', type: :request do
     {
       project_id: project.name,
       doc: {
-        body: 'doctor findings',
+        text: 'doctor findings',
         sourcedb: 'Example',
         sourceid: '001'
       },


### PR DESCRIPTION
## 概要

curlコマンドでDocument追加時のパラメーター名をbodyからtextに変える変更を行いました。


## 動作確認

- 以下のcurlコマンドでDocを作成できることを確認

前提: Test1という名称のProjectが存在している
```
 % curl -X POST http://localhost:3000/docs.json \
  -H "Content-Type: application/json" \
  -u "admin@pubannotation.org:abc123" \
  -d '{
    "project_id": "Test1",            
    "doc": {
      "text": "Doctor findings about the chest X-ray.",
      "sourcedb": "Example",
      "sourceid": "001"
    },
    "commit": "Create"
  }'
```

- http://localhost:3000/projects/Test1/docs/new からDocを作成できることを確認
- 作成したDocを編集画面経由で変更できることを確認