### PR TITLE
Use request.content_type instead of request.format for JSON auth check in docs

### DIFF
--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -6,8 +6,8 @@ class DocsController < ApplicationController
 
 	protect_from_forgery :except => [:create]
 	before_action :authenticate_user!, :only => [:new, :create, :create_from_upload, :edit, :update, :destroy, :project_delete_doc, :uptodate]
-	before_action :http_basic_authenticate, :only => :create, :if => Proc.new{|c| c.request.format == 'application/jsonrequest'}
-	skip_before_action :authenticate_user!, :verify_authenticity_token, :if => Proc.new{|c| c.request.format == 'application/jsonrequest'}
+	before_action :http_basic_authenticate, :only => :create, :if => Proc.new{|c| c.request.content_type&.start_with?('application/json')}
+	skip_before_action :authenticate_user!, :verify_authenticity_token, :if => Proc.new{|c| c.request.content_type&.start_with?('application/json')}
 
 	autocomplete :doc, :sourcedb
 

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -6,8 +6,8 @@ class DocsController < ApplicationController
 
 	protect_from_forgery :except => [:create]
 	before_action :authenticate_user!, :only => [:new, :create, :create_from_upload, :edit, :update, :destroy, :project_delete_doc, :uptodate]
-	before_action :http_basic_authenticate, :only => :create, :if => Proc.new{|c| c.request.content_type&.start_with?('application/json')}
-	skip_before_action :authenticate_user!, :verify_authenticity_token, :if => Proc.new{|c| c.request.content_type&.start_with?('application/json')}
+	before_action :http_basic_authenticate, :only => :create, :if => :json_request?
+	skip_before_action :authenticate_user!, :verify_authenticity_token, :if => :json_request?
 
 	autocomplete :doc, :sourcedb
 
@@ -659,6 +659,10 @@ class DocsController < ApplicationController
 	#   render :json => Doc.where(['LOWER(sourcedb) like ?', "%#{params[:term].downcase}%"]).collect{|doc| doc.sourcedb}.uniq
 	# end
 	private
+
+	def json_request?
+		request.media_type == 'application/json'
+	end
 
 	def set_highlight_text(doc, highlight_text)
 		# Only set highlight text if it exists (kNN-only results have no highlights)

--- a/spec/requests/docs_content_type_spec.rb
+++ b/spec/requests/docs_content_type_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'POST /docs.json content type authentication', type: :request do
+  before do
+    allow(Elasticsearch::IndexQueue).to receive(:index_doc)
+    allow(Elasticsearch::IndexQueue).to receive(:delete_doc)
+    allow(Elasticsearch::IndexQueue).to receive(:update_embedding)
+  end
+
+  let(:password) { 'password' }
+  let(:user) { create(:user, password: password).tap(&:confirm) }
+  let(:project) { create(:project, user: user) }
+
+  let(:doc_params) do
+    {
+      project_id: project.name,
+      doc: { text: 'test', sourcedb: 'Example', sourceid: '001' },
+      commit: 'Create'
+    }
+  end
+
+  let(:basic_auth_headers) do
+    { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(user.email, password) }
+  end
+
+  context 'with Content-Type: application/json' do
+    it 'authenticates via Basic auth and creates a doc' do
+      expect {
+        post '/docs.json',
+             params: doc_params.to_json,
+             headers: basic_auth_headers.merge('CONTENT_TYPE' => 'application/json')
+      }.to change(Doc, :count).by(1)
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'rejects request without Basic auth credentials' do
+      expect {
+        post '/docs.json',
+             params: doc_params.to_json,
+             headers: { 'CONTENT_TYPE' => 'application/json' }
+      }.not_to change(Doc, :count)
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'with Content-Type: application/jsonrequest' do
+    it 'does not accept Basic auth and rejects without session auth' do
+      expect {
+        post '/docs.json',
+             params: doc_params.to_json,
+             headers: { 'CONTENT_TYPE' => 'application/jsonrequest' }
+      }.not_to change(Doc, :count)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

docs_controller と projects_controller で Doc作成時の認証判定に使う Content-Type を application/jsonrequest から application/json に変更

## 動作確認

追加したspecを含む全てのspecがパスすることを確認
curl では手動でセッションをクリアした状態を再現するのが難しいためspecでの確認のみにとどめました