### PR TITLE
Add media form to create Doc form

### DIFF
--- a/app/views/docs/_form.html.erb
+++ b/app/views/docs/_form.html.erb
@@ -26,6 +26,24 @@
 				</table>
 			</td>
 		</tr>
+	<% if @doc.new_record? %>
+	<tr>
+		<th>Media</th>
+		<td>
+			Leave it blank if not associated with a media.
+			<table>
+				<tr>
+					<th>Media Source DB</th>
+					<td><%= text_field_tag 'media[sourcedb]' %></td>
+				</tr>
+				<tr>
+					<th>Media Source Id</th>
+					<td><%= text_field_tag 'media[sourceid]' %></td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+	<% end %>
 	</table>
 
 	<%= f.hidden_field :username, value: current_user.username -%>


### PR DESCRIPTION
## 概要

Create a new document フォームにmediaのsourcedbとsourceidを指定できるテキストボックスを追加しました。

## 動作確認

ブラウザ上の動作確認を行いました。

[作業手順]

1. 適当な新規Docフォーム(例: http://localhost:3000/projects/PubMed_Project/docs/new )にmediaのsourcedbとsourceidを指定できるテキストボックスが作成されていることを確認
<img width="1039" height="722" alt="スクリーンショット 2026-06-26 11 40 57" src="https://github.com/user-attachments/assets/c938e264-b700-491f-98e1-b3d84a62d523" />

2. 入力した内容のmediaが存在している場合、作成されたdocにmediaが紐づいていることを確認
3. 入力した内容のmediaが存在していない場合はDocが作成されないこと
4. Docの編集画面にmediaのsourcedbとsourceidを指定できるテキストボックスが表示されないことを確認