### PR TITLE
Media access control

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,12 +7,7 @@ class ApplicationController < ActionController::Base
 		user_signed_in? && current_user.root?
 	end
 
-	def media_accessible?
-		user_signed_in? && (current_user.root? || current_user.can_use_media?)
-	end
-
 	helper_method :root_user?
-	helper_method :media_accessible?
 
 	protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,12 @@ class ApplicationController < ActionController::Base
 		user_signed_in? && current_user.root?
 	end
 
+	def media_accessible?
+		user_signed_in? && (current_user.root? || current_user.can_use_media?)
+	end
+
 	helper_method :root_user?
+	helper_method :media_accessible?
 
 	protected
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -46,7 +46,7 @@ class MediaController < ApplicationController
   end
 
   def authorize_media_access!
-    unless media_accessible?
+    unless current_user&.can_access_media?
       render_status_error(:forbidden)
     end
   end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -2,6 +2,7 @@ class MediaController < ApplicationController
   include MediumHelper
 
   before_action :authenticate_user!
+  before_action :authorize_media_access!
   before_action :set_medium, only: [:show, :destroy]
   before_action :authorize_destroy!, only: [:destroy]
 
@@ -42,6 +43,12 @@ class MediaController < ApplicationController
 
   def bulk_upload_params
     params.expect(:zip_file)
+  end
+
+  def authorize_media_access!
+    unless media_accessible?
+      render_status_error(:forbidden)
+    end
   end
 
   def set_medium

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,10 @@ class User < ActiveRecord::Base
 		root
 	end
 
+	def can_access_media?
+		root? || can_use_media?
+	end
+
 	def manager?
 		manager
 	end

--- a/app/views/docs/_form.html.erb
+++ b/app/views/docs/_form.html.erb
@@ -26,7 +26,7 @@
 				</table>
 			</td>
 		</tr>
-	<% if @doc.new_record? && media_accessible? %>
+	<% if @doc.new_record? && current_user&.can_access_media? %>
 	<tr>
 		<th>Media</th>
 		<td>

--- a/app/views/docs/_form.html.erb
+++ b/app/views/docs/_form.html.erb
@@ -26,7 +26,7 @@
 				</table>
 			</td>
 		</tr>
-	<% if @doc.new_record? %>
+	<% if @doc.new_record? && media_accessible? %>
 	<tr>
 		<th>Media</th>
 		<td>

--- a/app/views/docs/show.html.erb
+++ b/app/views/docs/show.html.erb
@@ -225,7 +225,7 @@
 	<%= render :partial => 'docs/content'-%>
 	<%= render :partial => 'docs/divisions'-%>
 
-	<% if @medium.present? %>
+	<% if @medium.present? && media_accessible? %>
 		<section>
 			<h2>Media</h2>
 			<%= image_tag url_for(@medium.file), style: 'max-width: 100%' %>

--- a/app/views/docs/show.html.erb
+++ b/app/views/docs/show.html.erb
@@ -225,7 +225,7 @@
 	<%= render :partial => 'docs/content'-%>
 	<%= render :partial => 'docs/divisions'-%>
 
-	<% if @medium.present? && media_accessible? %>
+	<% if @medium.present? && current_user&.can_access_media? %>
 		<section>
 			<h2>Media</h2>
 			<%= image_tag url_for(@medium.file), style: 'max-width: 100%' %>

--- a/app/views/docs/show_in_project.html.erb
+++ b/app/views/docs/show_in_project.html.erb
@@ -8,7 +8,7 @@
 		<%= render :partial => 'docs/content'-%>
 		<%= render :partial => 'docs/divisions'-%>
 
-		<% if @medium.present? %>
+		<% if @medium.present? && media_accessible? %>
 			<section>
 				<h2>Media</h2>
 				<%= image_tag url_for(@medium.file), style: 'max-width: 100%' %>

--- a/app/views/docs/show_in_project.html.erb
+++ b/app/views/docs/show_in_project.html.erb
@@ -8,7 +8,7 @@
 		<%= render :partial => 'docs/content'-%>
 		<%= render :partial => 'docs/divisions'-%>
 
-		<% if @medium.present? && media_accessible? %>
+		<% if @medium.present? && current_user&.can_access_media? %>
 			<section>
 				<h2>Media</h2>
 				<%= image_tag url_for(@medium.file), style: 'max-width: 100%' %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:username) { |n| "testuser#{n}" }
     sequence(:email) { |n| "testuser#{n}@example.com" }
     password { "password" }
+    can_use_media { true }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User do
+  describe '#can_access_media?' do
+    subject { user.can_access_media? }
+
+    context 'when root' do
+      let(:user) { build(:user, root: true, can_use_media: false) }
+      it { is_expected.to be true }
+    end
+
+    context 'when can_use_media is true' do
+      let(:user) { build(:user, root: false, can_use_media: true) }
+      it { is_expected.to be true }
+    end
+
+    context 'when neither root nor can_use_media' do
+      let(:user) { build(:user, root: false, can_use_media: false) }
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Mediaを扱えるフラグがtrueのユーザー(user.can_use_media: true)とadminユーザー(user.root: true)がmedia関連の機能を利用できるように修正

対象

- `/media`パス配下(media_controller)のページ・アクション全般
  - Doc新規作成画面
  - Doc詳細画面 

## 動作確認

メディアを使えないユーザーとメディアを使えないユーザーを作成
```ruby
# メディアを使えるユーザー
User.create!(
  username: "mediauser",
  email: "mediauser@example.com",
  password: "password",
  password_confirmation: "password",
  can_use_media: true,
  root: false
).confirm

# メディアを使えないユーザー
User.create!(
  username: "normaluser",
  email: "normaluser@example.com",
  password: "password",
  password_confirmation: "password",
  can_use_media: false,
  root: false
).confirm
```

- それぞれで以下の画面を確認
  - http://localhost:3000/projects/PubMed_Project/docs/new
  - Mediaと紐付け済みのDoc詳細画面
- 一般ユーザーとしてmedia関連ページを開こうとすると403ページが表示されること
  - http://localhost:3000/media