### PR TITLE
Add UseJobRecordConcern to MediaBulkUploadJob for progress tracking

### DIFF
--- a/app/jobs/media_bulk_upload_job.rb
+++ b/app/jobs/media_bulk_upload_job.rb
@@ -13,13 +13,17 @@ class MediaBulkUploadJob < ApplicationJob
 
   def perform(user, zip_path)
     service = MediumBulkUploadService.new(zip_path, user)
-    service.call
 
-    prepare_progress_record(service.success_count + service.error_messages.size)
-    service.success_count.times { increment_progress }
-    service.error_messages.each do |error|
-      @job&.add_message(sourcedb: '*', sourceid: '*', body: error)
+    prepare_progress_record(service.total_count)
+
+    service.call do |result|
+      if result.status == :error
+        @job&.add_message(sourcedb: '*', sourceid: '*', body: result.message)
+      end
+
       increment_progress
+      check_suspend_flag
+
     end
   ensure
     FileUtils.rm_f(zip_path)

--- a/app/jobs/media_bulk_upload_job.rb
+++ b/app/jobs/media_bulk_upload_job.rb
@@ -1,4 +1,6 @@
 class MediaBulkUploadJob < ApplicationJob
+  include UseJobRecordConcern
+
   queue_as :general
 
   def self.enqueue(user, uploaded_file)
@@ -10,8 +12,20 @@ class MediaBulkUploadJob < ApplicationJob
   end
 
   def perform(user, zip_path)
-    MediumBulkUploadService.new(zip_path, user).call
+    service = MediumBulkUploadService.new(zip_path, user)
+    service.call
+
+    prepare_progress_record(service.success_count + service.error_messages.size)
+    service.success_count.times { increment_progress }
+    service.error_messages.each do |error|
+      @job&.add_message(sourcedb: '*', sourceid: '*', body: error)
+      increment_progress
+    end
   ensure
     FileUtils.rm_f(zip_path)
+  end
+
+  def job_name
+    'Media Bulk Upload'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ActiveRecord::Base
 	attr_accessor :login
 
 	has_many :projects, :dependent => :destroy
+	has_many :jobs, as: :organization, dependent: :destroy
 	has_many :associate_maintainers, :dependent => :destroy
 	has_many :associate_maintaiain_projects, :through => :associate_maintainers, :source => :project, :class_name => 'Project'
 	has_one :access_token, dependent: :destroy

--- a/app/services/medium_bulk_upload_service.rb
+++ b/app/services/medium_bulk_upload_service.rb
@@ -6,6 +6,14 @@ class MediumBulkUploadService
     @errors = []
   end
 
+  def success_count
+    @successes.size
+  end
+
+  def error_messages
+    @errors
+  end
+
   def call
     Zip::File.open(@zip_path) do |zip|
       zip.each do |entry|

--- a/app/services/medium_bulk_upload_service.rb
+++ b/app/services/medium_bulk_upload_service.rb
@@ -1,23 +1,25 @@
 class MediumBulkUploadService
+  Result = Data.define(:filename, :status, :message)
+
   def initialize(zip_path, user)
     @zip_path = zip_path
     @user = user
-    @successes = []
-    @errors = []
   end
 
-  def success_count
-    @successes.size
-  end
-
-  def error_messages
-    @errors
+  def total_count
+    @total_count ||= Zip::File.open(@zip_path) do |zip|
+      zip.count { |entry| !skippable_entry?(entry) }
+    end
+  rescue Zip::Error => e
+    raise ArgumentError, "Invalid ZIP file: #{e.message}"
   end
 
   def call
     Zip::File.open(@zip_path) do |zip|
       zip.each do |entry|
-        process_entry(entry)
+        next if skippable_entry?(entry)
+        result = process_entry(entry)
+        yield result if block_given?
       end
     end
   rescue Zip::Error => e
@@ -25,6 +27,14 @@ class MediumBulkUploadService
   end
 
   private
+
+  def success_result(filename)
+    Result.new(filename:, status: :success, message: nil)
+  end
+
+  def error_result(filename, message)
+    Result.new(filename:, status: :error, message:)
+  end
 
   def skippable_entry?(entry)
     filename = File.basename(entry.name)
@@ -35,8 +45,7 @@ class MediumBulkUploadService
   end
 
   def process_entry(entry)
-    return if skippable_entry?(entry)
-
+    filename = File.basename(entry.name)
     upload_entry = MediumUploadEntryParser.call(entry)
 
     Tempfile.create(["media-upload-", upload_entry.ext]) do |tmp|
@@ -49,15 +58,15 @@ class MediumBulkUploadService
         medium = upload_entry.create_medium(user: @user, io: tmp)
 
         if medium.persisted?
-          @successes << upload_entry.filename
+          success_result(upload_entry.filename)
         else
-          @errors << "#{upload_entry.filename}: #{medium.errors.full_messages.join(', ')}"
+          error_result(upload_entry.filename, medium.errors.full_messages.join(', '))
         end
       ensure
         input.close
       end
     end
   rescue MediumUploadEntry::ValidationError => e
-    @errors << e.message
+    error_result(filename, e.message)
   end
 end

--- a/spec/jobs/media_bulk_upload_job_spec.rb
+++ b/spec/jobs/media_bulk_upload_job_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MediaBulkUploadJob, type: :job do
+  let(:user) { create(:user) }
+
+  def setup_job_record(user)
+    job_record = create(:job, organization: user)
+    allow(job_record).to receive(:update_attribute)
+    allow(job_record).to receive(:increment!)
+    allow(job_record).to receive(:add_message)
+    allow(job_record).to receive(:start!)
+    allow(job_record).to receive(:finish!)
+
+    allow_any_instance_of(MediaBulkUploadJob).to receive(:before_perform) do |job_instance, _active_job|
+      job_instance.instance_variable_set(:@job, job_record)
+    end
+
+    job_record
+  end
+
+  def stub_service(total_count:, results: [])
+    service = instance_double(MediumBulkUploadService, total_count: total_count)
+    expectation = allow(service).to receive(:call)
+    results.each { |result| expectation.and_yield(result) }
+    allow(MediumBulkUploadService).to receive(:new).and_return(service)
+    service
+  end
+
+  def result(status:, filename: 'PMC-1.png', message: nil)
+    MediumBulkUploadService::Result.new(filename:, status:, message:)
+  end
+
+  describe '.enqueue' do
+    let(:tempfile) do
+      Tempfile.new(['upload', '.zip']).tap do |f|
+        f.write('dummy zip content')
+        f.close
+      end
+    end
+
+    it 'enqueues a MediaBulkUploadJob for the user' do
+      expect {
+        MediaBulkUploadJob.enqueue(user, tempfile)
+      }.to have_enqueued_job(MediaBulkUploadJob).with(user, instance_of(String))
+    end
+
+    it 'moves the uploaded file under tmp/media_bulk_uploads and removes the original' do
+      original_path = tempfile.path
+
+      enqueued_zip_path = nil
+      allow(MediaBulkUploadJob).to receive(:perform_later) do |_user, zip_path|
+        enqueued_zip_path = zip_path
+      end
+
+      MediaBulkUploadJob.enqueue(user, tempfile)
+
+      expect(enqueued_zip_path).to match(%r{tmp/media_bulk_uploads/.+\.zip\z})
+      expect(File.exist?(enqueued_zip_path)).to be true
+      expect(File.exist?(original_path)).to be false
+    ensure
+      FileUtils.rm_f(enqueued_zip_path)
+    end
+  end
+
+  describe '#perform' do
+    let(:zip_path) { Rails.root.join('tmp', "media_bulk_upload_job_spec_#{SecureRandom.hex(4)}.zip").to_s }
+
+    before { FileUtils.touch(zip_path) }
+
+    it 'initializes progress tracking with the service total_count' do
+      job_record = setup_job_record(user)
+      stub_service(total_count: 3)
+
+      MediaBulkUploadJob.perform_now(user, zip_path)
+
+      expect(job_record).to have_received(:update_attribute).with(:num_items, 3)
+      expect(job_record).to have_received(:update_attribute).with(:num_dones, 0)
+    end
+
+    it 'increments progress for every yielded result, success or error' do
+      job_record = setup_job_record(user)
+      stub_service(total_count: 2, results: [result(status: :success), result(status: :error, message: 'boom')])
+
+      MediaBulkUploadJob.perform_now(user, zip_path)
+
+      expect(job_record).to have_received(:increment!).with(:num_dones, 1).twice
+    end
+
+    it 'records a job message only for error results' do
+      job_record = setup_job_record(user)
+      stub_service(total_count: 2, results: [result(status: :success), result(status: :error, message: 'boom')])
+
+      MediaBulkUploadJob.perform_now(user, zip_path)
+
+      expect(job_record).to have_received(:add_message).with(sourcedb: '*', sourceid: '*', body: 'boom').once
+    end
+
+    it 'stops incrementing progress once the job is suspended' do
+      job_record = setup_job_record(user)
+      stub_service(total_count: 2, results: [result(status: :success), result(status: :success)])
+
+      call_count = 0
+      allow_any_instance_of(MediaBulkUploadJob).to receive(:check_suspend_flag) do
+        call_count += 1
+        raise Exceptions::JobSuspendError if call_count == 1
+      end
+
+      MediaBulkUploadJob.perform_now(user, zip_path)
+
+      expect(job_record).to have_received(:increment!).with(:num_dones, 1).once
+    end
+
+    it 'removes the zip file after processing completes' do
+      setup_job_record(user)
+      stub_service(total_count: 0)
+
+      MediaBulkUploadJob.perform_now(user, zip_path)
+
+      expect(File.exist?(zip_path)).to be false
+    end
+
+    it 'removes the zip file even when the service raises an error' do
+      setup_job_record(user)
+      service = instance_double(MediumBulkUploadService, total_count: 0)
+      allow(service).to receive(:call).and_raise(ArgumentError, 'Invalid ZIP file')
+      allow(MediumBulkUploadService).to receive(:new).and_return(service)
+
+      expect { MediaBulkUploadJob.perform_now(user, zip_path) }.not_to raise_error
+
+      expect(File.exist?(zip_path)).to be false
+    end
+  end
+
+  describe '#job_name' do
+    it 'returns a descriptive name' do
+      job = MediaBulkUploadJob.new(user, 'dummy_path.zip')
+      expect(job.job_name).to eq('Media Bulk Upload')
+    end
+  end
+end

--- a/spec/services/medium_bulk_upload_service_spec.rb
+++ b/spec/services/medium_bulk_upload_service_spec.rb
@@ -18,6 +18,22 @@ RSpec.describe MediumBulkUploadService do
     end
   end
 
+  def collect_results(service)
+    [].tap { |results| service.call { |r| results << r } }
+  end
+
+  describe '#total_count' do
+    it 'returns the number of non-skippable entries' do
+      zip_file = build_zip({
+        'PMC-12345.png' => png_data,
+        'PMC-67890.png' => png_data,
+        '.DS_Store' => '',
+        '__MACOSX/._PMC-12345.png' => ''
+      })
+      expect(described_class.new(zip_file.path, user).total_count).to eq(2)
+    end
+  end
+
   describe '#call' do
     context 'with valid image files' do
       let(:zip_file) { build_zip({ 'PMC-12345.png' => png_data }) }
@@ -34,11 +50,10 @@ RSpec.describe MediumBulkUploadService do
         expect(medium).to be_present
       end
 
-      it 'reports success' do
-        service = described_class.new(zip_file.path, user)
-        service.call
-        expect(service.success_count).to eq(1)
-        expect(service.error_messages).to be_empty
+      it 'yields a success result' do
+        results = collect_results(described_class.new(zip_file.path, user))
+        expect(results.count { |r| r.status == :success }).to eq(1)
+        expect(results.none? { |r| r.status == :error }).to be true
       end
     end
 
@@ -52,54 +67,53 @@ RSpec.describe MediumBulkUploadService do
       end
 
       it 'skips .DS_Store and __MACOSX files' do
-        service = described_class.new(zip_file.path, user)
-        service.call
+        results = collect_results(described_class.new(zip_file.path, user))
         expect(Medium.count).to eq(1)
-        expect(service.success_count).to eq(1)
-        expect(service.error_messages).to be_empty
+        expect(results.count { |r| r.status == :success }).to eq(1)
+        expect(results.none? { |r| r.status == :error }).to be true
       end
     end
 
     context 'with a file without extension' do
       let(:zip_file) { build_zip({ 'PMC-12345' => '' }) }
 
-      it 'reports an error' do
-        service = described_class.new(zip_file.path, user)
-        service.call
-        expect(service.error_messages.first).to include('no extension')
+      it 'yields an error result' do
+        results = collect_results(described_class.new(zip_file.path, user))
+        expect(results.first.status).to eq(:error)
+        expect(results.first.message).to include('no extension')
       end
     end
 
     context 'with an unsupported extension' do
       let(:zip_file) { build_zip({ 'PMC-12345.txt' => '' }) }
 
-      it 'reports an error' do
-        service = described_class.new(zip_file.path, user)
-        service.call
-        expect(service.error_messages.first).to include('unsupported extension')
+      it 'yields an error result' do
+        results = collect_results(described_class.new(zip_file.path, user))
+        expect(results.first.status).to eq(:error)
+        expect(results.first.message).to include('unsupported extension')
       end
     end
 
     context 'with invalid filename format' do
-      it 'reports error for filename with spaces' do
+      it 'yields an error for filename with spaces' do
         zip_file = build_zip({ 'my file-001.png' => png_data })
-        service = described_class.new(zip_file.path, user)
-        service.call
-        expect(service.error_messages.first).to include('sourcedb-sourceid')
+        results = collect_results(described_class.new(zip_file.path, user))
+        expect(results.first.status).to eq(:error)
+        expect(results.first.message).to include('sourcedb-sourceid')
       end
 
-      it 'reports error for filename with multiple hyphens' do
+      it 'yields an error for filename with multiple hyphens' do
         zip_file = build_zip({ 'PMC-sub-12345.png' => png_data })
-        service = described_class.new(zip_file.path, user)
-        service.call
-        expect(service.error_messages.first).to include('sourcedb-sourceid')
+        results = collect_results(described_class.new(zip_file.path, user))
+        expect(results.first.status).to eq(:error)
+        expect(results.first.message).to include('sourcedb-sourceid')
       end
 
-      it 'reports error for filename without hyphen' do
+      it 'yields an error for filename without hyphen' do
         zip_file = build_zip({ 'PMC12345.png' => png_data })
-        service = described_class.new(zip_file.path, user)
-        service.call
-        expect(service.error_messages.first).to include('sourcedb-sourceid')
+        results = collect_results(described_class.new(zip_file.path, user))
+        expect(results.first.status).to eq(:error)
+        expect(results.first.message).to include('sourcedb-sourceid')
       end
     end
 

--- a/spec/services/medium_bulk_upload_service_spec.rb
+++ b/spec/services/medium_bulk_upload_service_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe MediumBulkUploadService do
         medium = Medium.find_by(sourcedb: 'PMC', sourceid: '12345')
         expect(medium).to be_present
       end
+
+      it 'reports success' do
+        service = described_class.new(zip_file.path, user)
+        service.call
+        expect(service.success_count).to eq(1)
+        expect(service.error_messages).to be_empty
+      end
     end
 
     context 'with macOS metadata files' do
@@ -44,52 +51,55 @@ RSpec.describe MediumBulkUploadService do
         })
       end
 
-      it 'skips .DS_Store and __MACOSX files and creates only valid media' do
-        described_class.new(zip_file.path, user).call
+      it 'skips .DS_Store and __MACOSX files' do
+        service = described_class.new(zip_file.path, user)
+        service.call
         expect(Medium.count).to eq(1)
+        expect(service.success_count).to eq(1)
+        expect(service.error_messages).to be_empty
       end
     end
 
     context 'with a file without extension' do
       let(:zip_file) { build_zip({ 'PMC-12345' => '' }) }
 
-      it 'does not create a Medium' do
-        expect {
-          described_class.new(zip_file.path, user).call
-        }.not_to change(Medium, :count)
+      it 'reports an error' do
+        service = described_class.new(zip_file.path, user)
+        service.call
+        expect(service.error_messages.first).to include('no extension')
       end
     end
 
     context 'with an unsupported extension' do
       let(:zip_file) { build_zip({ 'PMC-12345.txt' => '' }) }
 
-      it 'does not create a Medium' do
-        expect {
-          described_class.new(zip_file.path, user).call
-        }.not_to change(Medium, :count)
+      it 'reports an error' do
+        service = described_class.new(zip_file.path, user)
+        service.call
+        expect(service.error_messages.first).to include('unsupported extension')
       end
     end
 
     context 'with invalid filename format' do
-      it 'does not create a Medium for filename with spaces' do
+      it 'reports error for filename with spaces' do
         zip_file = build_zip({ 'my file-001.png' => png_data })
-        expect {
-          described_class.new(zip_file.path, user).call
-        }.not_to change(Medium, :count)
+        service = described_class.new(zip_file.path, user)
+        service.call
+        expect(service.error_messages.first).to include('sourcedb-sourceid')
       end
 
-      it 'does not create a Medium for filename with multiple hyphens' do
+      it 'reports error for filename with multiple hyphens' do
         zip_file = build_zip({ 'PMC-sub-12345.png' => png_data })
-        expect {
-          described_class.new(zip_file.path, user).call
-        }.not_to change(Medium, :count)
+        service = described_class.new(zip_file.path, user)
+        service.call
+        expect(service.error_messages.first).to include('sourcedb-sourceid')
       end
 
-      it 'does not create a Medium for filename without hyphen' do
+      it 'reports error for filename without hyphen' do
         zip_file = build_zip({ 'PMC12345.png' => png_data })
-        expect {
-          described_class.new(zip_file.path, user).call
-        }.not_to change(Medium, :count)
+        service = described_class.new(zip_file.path, user)
+        service.call
+        expect(service.error_messages.first).to include('sourcedb-sourceid')
       end
     end
 


### PR DESCRIPTION
## 概要

#259 からMediaBulkUploadJob が UseJobRecordConcern を使って Job / Message / progress を記録する変更を切り出しました。
このブランチをマージ後に #259 をmasterでrebaseする予定です。

## 動作確認

- 追加分を含むspecが全件パスすることを確認
- ブラウザとコンソールを使用して動作確認

[操作手順]

Media bulk upload Job 完了後に、コンソールでUserにJobが紐づいていることを確認

```ruby
user = User.find_by(username: "admin")

user.jobs.last
# => Jobテーブルのレコードが取得される

user.jobs.last.messages
# =>  []（エラーがあれば配列にMessageテーブルのレコードが入る）
```