### PR TITLE
Media upload support video audio

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -19,9 +19,11 @@ class MediaController < ApplicationController
   end
 
   def create
+    content_type = params[:medium][:file]&.content_type
     @medium = Medium.new(medium_params)
     @medium.user = current_user
-    @medium.content_type = params[:medium][:file]&.content_type
+    @medium.content_type = content_type
+    @medium.media_type = media_type_from_content_type(content_type)
 
     if @medium.save
       redirect_to new_medium_path, notice: 'Media was successfully uploaded.'
@@ -68,6 +70,10 @@ class MediaController < ApplicationController
   end
 
   def medium_params
-    params.expect(medium: [:sourcedb, :sourceid, :media_type, :file])
+    params.expect(medium: [:sourcedb, :sourceid, :file])
+  end
+
+  def media_type_from_content_type(content_type)
+    content_type.to_s.split('/').first
   end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -19,11 +19,9 @@ class MediaController < ApplicationController
   end
 
   def create
-    content_type = params[:medium][:file]&.content_type
     @medium = Medium.new(medium_params)
     @medium.user = current_user
-    @medium.content_type = content_type
-    @medium.media_type = media_type_from_content_type(content_type)
+    @medium.content_type = params[:medium][:file]&.content_type
 
     if @medium.save
       redirect_to new_medium_path, notice: 'Media was successfully uploaded.'
@@ -71,9 +69,5 @@ class MediaController < ApplicationController
 
   def medium_params
     params.expect(medium: [:sourcedb, :sourceid, :file])
-  end
-
-  def media_type_from_content_type(content_type)
-    content_type.to_s.split('/').first
   end
 end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -14,8 +14,16 @@ class Medium < ApplicationRecord
     audio/mpeg audio/wav audio/ogg
   ].freeze
 
+  before_validation :set_media_type_from_content_type
+
   validates :sourcedb, presence: true
   validates :sourceid, presence: true, uniqueness: { scope: :sourcedb }
   validates :media_type, presence: true
   validates :content_type, presence: true, inclusion: { in: ALLOWED_CONTENT_TYPES }
+
+  private
+
+  def set_media_type_from_content_type
+    self.media_type = content_type.split('/').first if media_type.blank? && content_type.present?
+  end
 end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -6,8 +6,16 @@ class Medium < ApplicationRecord
 
   enum :media_type, { image: 0, video: 1, audio: 2 }
 
+  # Browsers only play these natively in an HTML5 <video>/<audio> tag;
+  # e.g. video/quicktime (.mov) is rejected because Chrome/Firefox can't play it inline.
+  ALLOWED_CONTENT_TYPES = %w[
+    image/png image/jpeg image/gif image/webp
+    video/mp4 video/webm
+    audio/mpeg audio/wav audio/ogg
+  ].freeze
+
   validates :sourcedb, presence: true
   validates :sourceid, presence: true, uniqueness: { scope: :sourcedb }
   validates :media_type, presence: true
-  validates :content_type, presence: true
+  validates :content_type, presence: true, inclusion: { in: ALLOWED_CONTENT_TYPES }
 end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -24,6 +24,9 @@ class Medium < ApplicationRecord
   private
 
   def set_media_type_from_content_type
-    self.media_type = content_type.split('/').first if media_type.blank? && content_type.present?
+    return unless media_type.blank? && content_type.present?
+
+    derived_media_type = content_type.split('/').first
+    self.media_type = derived_media_type if self.class.media_types.key?(derived_media_type)
   end
 end

--- a/app/views/media/_form.html.erb
+++ b/app/views/media/_form.html.erb
@@ -16,10 +16,9 @@
 			<th><%= f.label :sourceid, 'Source ID' %></th>
 			<td><%= f.text_field :sourceid, required: true %></td>
 		</tr>
-		<%= f.hidden_field :media_type, value: :image %>
 		<tr>
 			<th><%= f.label :file, 'File' %></th>
-			<td><%= f.file_field :file, accept: 'image/*', required: true %></td>
+			<td><%= f.file_field :file, accept: 'image/*,video/*,audio/*', required: true %></td>
 		</tr>
 		<tr>
 			<th></th>

--- a/app/views/media/_form.html.erb
+++ b/app/views/media/_form.html.erb
@@ -18,7 +18,7 @@
 		</tr>
 		<tr>
 			<th><%= f.label :file, 'File' %></th>
-			<td><%= f.file_field :file, accept: 'image/*,video/*,audio/*', required: true %></td>
+			<td><%= f.file_field :file, accept: Medium::ALLOWED_CONTENT_TYPES.join(','), required: true %></td>
 		</tr>
 		<tr>
 			<th></th>

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe 'MediaController', type: :request do
       'audio/mpeg'
     )
   end
+  let(:quicktime_file) do
+    Rack::Test::UploadedFile.new(
+      Rails.root.join('spec', 'fixtures', 'files', 'test_video.mp4'),
+      'video/quicktime'
+    )
+  end
 
   describe 'GET /media' do
     let!(:medium) { create(:medium) }
@@ -132,6 +138,19 @@ RSpec.describe 'MediaController', type: :request do
             sourceid: 'img-001'
           }
         }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'rejects a video/quicktime file that browsers cannot play inline' do
+        expect {
+          post media_path, params: {
+            medium: {
+              sourcedb: 'TestDB',
+              sourceid: 'mov-001',
+              file: quicktime_file
+            }
+          }
+        }.not_to change(Medium, :count)
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe 'MediaController', type: :request do
       'image/png'
     )
   end
+  let(:video_file) do
+    Rack::Test::UploadedFile.new(
+      Rails.root.join('spec', 'fixtures', 'files', 'test_video.mp4'),
+      'video/mp4'
+    )
+  end
+  let(:audio_file) do
+    Rack::Test::UploadedFile.new(
+      Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3'),
+      'audio/mpeg'
+    )
+  end
 
   describe 'GET /media' do
     let!(:medium) { create(:medium) }
@@ -73,26 +85,51 @@ RSpec.describe 'MediaController', type: :request do
     context 'when logged in' do
       before { sign_in user }
 
-      it 'creates a medium with valid params' do
+      it 'creates a medium with valid params and derives media_type from the file' do
         expect {
           post media_path, params: {
             medium: {
               sourcedb: 'TestDB',
               sourceid: 'img-001',
-              media_type: 'image',
               file: image_file
             }
           }
         }.to change(Medium, :count).by(1)
+        expect(Medium.last.media_type).to eq('image')
         expect(response).to redirect_to(new_medium_path)
+      end
+
+      it 'creates a medium with a video file' do
+        expect {
+          post media_path, params: {
+            medium: {
+              sourcedb: 'TestDB',
+              sourceid: 'video-001',
+              file: video_file
+            }
+          }
+        }.to change(Medium, :count).by(1)
+        expect(Medium.last.media_type).to eq('video')
+      end
+
+      it 'creates a medium with an audio file' do
+        expect {
+          post media_path, params: {
+            medium: {
+              sourcedb: 'TestDB',
+              sourceid: 'audio-001',
+              file: audio_file
+            }
+          }
+        }.to change(Medium, :count).by(1)
+        expect(Medium.last.media_type).to eq('audio')
       end
 
       it 'renders new with invalid params' do
         post media_path, params: {
           medium: {
             sourcedb: '',
-            sourceid: 'img-001',
-            media_type: 'image'
+            sourceid: 'img-001'
           }
         }
         expect(response).to have_http_status(:unprocessable_entity)
@@ -102,7 +139,7 @@ RSpec.describe 'MediaController', type: :request do
     context 'when not logged in' do
       it 'redirects to login' do
         post media_path, params: {
-          medium: { sourcedb: 'TestDB', sourceid: 'img-001', media_type: 'image' }
+          medium: { sourcedb: 'TestDB', sourceid: 'img-001' }
         }
         expect(response).to redirect_to(new_user_session_path)
       end

--- a/spec/fixtures/files/test_audio.mp3
+++ b/spec/fixtures/files/test_audio.mp3
@@ -1,0 +1,1 @@
+dummy audio content for tests

--- a/spec/fixtures/files/test_video.mp4
+++ b/spec/fixtures/files/test_video.mp4
@@ -1,0 +1,1 @@
+dummy video content for tests

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Medium, type: :model do
     it 'requires content_type' do
       expect(build(:medium, content_type: nil)).not_to be_valid
     end
+
+    it 'accepts a browser-playable video content_type' do
+      expect(build(:medium, media_type: :video, content_type: 'video/mp4')).to be_valid
+    end
+
+    it 'rejects a content_type browsers cannot play inline, such as video/quicktime' do
+      medium = build(:medium, media_type: :video, content_type: 'video/quicktime')
+      expect(medium).not_to be_valid
+      expect(medium.errors[:content_type]).to be_present
+    end
   end
 
   describe 'enums' do

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -26,12 +26,24 @@ RSpec.describe Medium, type: :model do
       expect(build(:medium, sourcedb: 'DB2', sourceid: 'id1')).to be_valid
     end
 
-    it 'requires media_type' do
-      expect(build(:medium, media_type: nil)).not_to be_valid
+    it 'requires media_type when it cannot be derived from content_type' do
+      expect(build(:medium, media_type: nil, content_type: nil)).not_to be_valid
     end
 
     it 'requires content_type' do
       expect(build(:medium, content_type: nil)).not_to be_valid
+    end
+
+    it 'derives media_type from content_type when media_type is not set' do
+      medium = build(:medium, media_type: nil, content_type: 'video/mp4')
+      expect(medium).to be_valid
+      expect(medium.media_type).to eq('video')
+    end
+
+    it 'does not override an explicitly set media_type' do
+      medium = build(:medium, media_type: :video, content_type: 'image/png')
+      medium.valid?
+      expect(medium.media_type).to eq('video')
     end
 
     it 'accepts a browser-playable video content_type' do

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe Medium, type: :model do
       expect(medium.media_type).to eq('video')
     end
 
+    it 'does not raise and stays invalid when content_type has no matching media_type' do
+      medium = build(:medium, media_type: nil, content_type: 'application/pdf')
+      expect { medium.valid? }.not_to raise_error
+      expect(medium).not_to be_valid
+      expect(medium.media_type).to be_nil
+    end
+
     it 'accepts a browser-playable video content_type' do
       expect(build(:medium, media_type: :video, content_type: 'video/mp4')).to be_valid
     end


### PR DESCRIPTION
## 概要

media upload(単体)を動画と音声に対応させました。
media詳細画面を動画と音声に対応させるのは次PRで行う予定です。


## 動作確認

- 追加分を含む全てのspecがパスすることを確認
- http://localhost:3000/media/new で以下のmp3とmp4の保存ができることを確認しました
  - [maou_se_system46.mp3](https://github.com/user-attachments/files/29694720/maou_se_system46.mp3)
  - https://github.com/user-attachments/assets/c4ebaaf1-7805-4b3b-a07a-a212815ab7e3
- media_typeとcontent_typeが意図した内容になっていることを確認しました。

