### PR TITLE
Media video audio playback

### DIFF
--- a/app/helpers/medium_helper.rb
+++ b/app/helpers/medium_helper.rb
@@ -7,9 +7,11 @@ module MediumHelper
     return unless medium.file.attached?
 
     url = url_for(medium.file)
+    # max-height keeps portrait video/images from filling the whole viewport.
+    style = 'max-width: 100%; max-height: 80vh'
     case medium.media_type
-    when 'image' then image_tag(url, **options)
-    when 'video' then video_tag(url, controls: true, **options)
+    when 'image' then image_tag(url, style:, **options)
+    when 'video' then video_tag(url, controls: true, style:, **options)
     when 'audio' then audio_tag(url, controls: true, **options)
     end
   end

--- a/app/helpers/medium_helper.rb
+++ b/app/helpers/medium_helper.rb
@@ -2,4 +2,15 @@ module MediumHelper
   def current_user_owns_medium?(medium)
     medium.user == current_user
   end
+
+  def medium_tag(medium, **options)
+    return unless medium.file.attached?
+
+    url = url_for(medium.file)
+    case medium.media_type
+    when 'image' then image_tag(url, **options)
+    when 'video' then video_tag(url, controls: true, **options)
+    when 'audio' then audio_tag(url, controls: true, **options)
+    end
+  end
 end

--- a/app/views/docs/show.html.erb
+++ b/app/views/docs/show.html.erb
@@ -228,7 +228,7 @@
 	<% if @medium.present? && current_user&.can_access_media? %>
 		<section>
 			<h2>Media</h2>
-			<%= image_tag url_for(@medium.file), style: 'max-width: 100%' %>
+			<%= medium_tag(@medium, style: 'max-width: 100%') %>
 			<p><%= link_to "#{@medium.sourcedb}:#{@medium.sourceid}", show_media_path(sourcedb: @medium.sourcedb, sourceid: @medium.sourceid) %></p>
 		</section>
 	<% end %>

--- a/app/views/docs/show.html.erb
+++ b/app/views/docs/show.html.erb
@@ -228,7 +228,7 @@
 	<% if @medium.present? && current_user&.can_access_media? %>
 		<section>
 			<h2>Media</h2>
-			<%= medium_tag(@medium, style: 'max-width: 100%') %>
+			<%= medium_tag(@medium) %>
 			<p><%= link_to "#{@medium.sourcedb}:#{@medium.sourceid}", show_media_path(sourcedb: @medium.sourcedb, sourceid: @medium.sourceid) %></p>
 		</section>
 	<% end %>

--- a/app/views/docs/show_in_project.html.erb
+++ b/app/views/docs/show_in_project.html.erb
@@ -11,7 +11,7 @@
 		<% if @medium.present? && current_user&.can_access_media? %>
 			<section>
 				<h2>Media</h2>
-				<%= medium_tag(@medium, style: 'max-width: 100%') %>
+				<%= medium_tag(@medium) %>
 				<p><%= link_to "#{@medium.sourcedb}:#{@medium.sourceid}", show_media_path(sourcedb: @medium.sourcedb, sourceid: @medium.sourceid) %></p>
 			</section>
 		<% end %>

--- a/app/views/docs/show_in_project.html.erb
+++ b/app/views/docs/show_in_project.html.erb
@@ -11,7 +11,7 @@
 		<% if @medium.present? && current_user&.can_access_media? %>
 			<section>
 				<h2>Media</h2>
-				<%= image_tag url_for(@medium.file), style: 'max-width: 100%' %>
+				<%= medium_tag(@medium, style: 'max-width: 100%') %>
 				<p><%= link_to "#{@medium.sourcedb}:#{@medium.sourceid}", show_media_path(sourcedb: @medium.sourcedb, sourceid: @medium.sourceid) %></p>
 			</section>
 		<% end %>

--- a/app/views/media/show.html.erb
+++ b/app/views/media/show.html.erb
@@ -7,11 +7,7 @@
 <section>
 	<h2><%= @medium.sourcedb %>:<%= @medium.sourceid %></h2>
 
-	<% if @medium.file.attached? %>
-		<% if @medium.image? %>
-			<%= image_tag url_for(@medium.file), style: 'max-width: 100%' %>
-		<% end %>
-	<% end %>
+	<%= medium_tag(@medium, style: 'max-width: 100%') %>
 
 	<table>
 		<tr>

--- a/app/views/media/show.html.erb
+++ b/app/views/media/show.html.erb
@@ -7,7 +7,7 @@
 <section>
 	<h2><%= @medium.sourcedb %>:<%= @medium.sourceid %></h2>
 
-	<%= medium_tag(@medium, style: 'max-width: 100%') %>
+	<%= medium_tag(@medium) %>
 
 	<table>
 		<tr>

--- a/spec/helpers/medium_helper_spec.rb
+++ b/spec/helpers/medium_helper_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MediumHelper, type: :helper do
+  describe '#medium_tag' do
+    let(:user) { create(:user) }
+
+    def attach_file(medium, filename, content_type)
+      medium.file.attach(
+        io: File.open(Rails.root.join('spec', 'fixtures', 'files', filename)),
+        filename:,
+        content_type:
+      )
+      medium.save!
+      medium
+    end
+
+    def parsed_tag(html)
+      Nokogiri::HTML::DocumentFragment.parse(html).children.first
+    end
+
+    context 'when no file is attached' do
+      it 'returns nil' do
+        medium = build(:medium, user:)
+        expect(helper.medium_tag(medium)).to be_nil
+      end
+    end
+
+    context 'when a file is attached' do
+      it 'renders an img tag capped to the viewport height for an image medium' do
+        medium = attach_file(build(:medium, user:, media_type: :image, content_type: 'image/png'), 'test_image.png', 'image/png')
+
+        node = parsed_tag(helper.medium_tag(medium))
+
+        expect(node.name).to eq('img')
+        expect(node['style']).to include('max-height: 80vh')
+      end
+
+      it 'renders a video tag with controls capped to the viewport height for a video medium' do
+        medium = attach_file(build(:medium, user:, media_type: :video, content_type: 'video/mp4'), 'test_video.mp4', 'video/mp4')
+
+        node = parsed_tag(helper.medium_tag(medium))
+
+        expect(node.name).to eq('video')
+        expect(node['controls']).to eq('controls')
+        expect(node['style']).to include('max-height: 80vh')
+      end
+
+      it 'renders an audio tag with controls for an audio medium' do
+        medium = attach_file(build(:medium, user:, media_type: :audio, content_type: 'audio/mpeg'), 'test_audio.mp3', 'audio/mpeg')
+
+        node = parsed_tag(helper.medium_tag(medium))
+
+        expect(node.name).to eq('audio')
+        expect(node['controls']).to eq('controls')
+      end
+    end
+  end
+end

--- a/spec/helpers/medium_helper_spec.rb
+++ b/spec/helpers/medium_helper_spec.rb
@@ -7,12 +7,10 @@ RSpec.describe MediumHelper, type: :helper do
     let(:user) { create(:user) }
 
     def attach_file(medium, filename, content_type)
-      medium.file.attach(
-        io: File.open(Rails.root.join('spec', 'fixtures', 'files', filename)),
-        filename:,
-        content_type:
-      )
-      medium.save!
+      File.open(Rails.root.join('spec', 'fixtures', 'files', filename), 'rb') do |file|
+        medium.file.attach(io: file, filename:, content_type:)
+        medium.save!
+      end
       medium
     end
 


### PR DESCRIPTION
## 概要

media詳細画面を動画と音声に対応させました

### 動画
<img width="1319" height="1251" alt="localhost_3000_media_sourcedbs_test_sourceids_testmovie" src="https://github.com/user-attachments/assets/ba2d259a-a059-4448-846b-b39cd63522fe" />

### 音声
<img width="1050" height="540" alt="スクリーンショット 2026-07-06 17 57 34" src="https://github.com/user-attachments/assets/1af5dc1e-fcba-46fb-b349-e751597eebe2" />

## 動作確認

- 追加分を含む全てのspecがパスすることを確認
- http://localhost:3000/media でアップロードしたメディアを詳細画面で閲覧できることを確認
