### PR TITLE
Media jobs manage

### DIFF
--- a/app/controllers/media/jobs_controller.rb
+++ b/app/controllers/media/jobs_controller.rb
@@ -1,7 +1,7 @@
 class Media::JobsController < ApplicationController
   before_action :authenticate_user!
   before_action :authorize_media_access!
-  before_action :set_job, only: [:show]
+  before_action :set_job, only: [:show, :destroy]
 
   rescue_from ActiveRecord::RecordNotFound do
     redirect_to media_jobs_path, notice: 'Could not find the job.'
@@ -22,6 +22,11 @@ class Media::JobsController < ApplicationController
   def latest_jobs_table
     load_jobs
     render partial: 'jobs_table', locals: { jobs: @jobs, message_counts: @job_message_counts, reload_necessary: @reload_necessary }
+  end
+
+  def destroy
+    @job.destroy_unless_running
+    redirect_to media_jobs_path
   end
 
   private

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -29,9 +29,20 @@ class MediaController < ApplicationController
     end
   end
 
+  def clear_finished_jobs
+    Job.batch_destroy_finished(current_user)
+    redirect_to media_jobs_path, notice: 'Finished jobs cleared.'
+  end
+
   def bulk_upload
-    MediaBulkUploadJob.enqueue(current_user, bulk_upload_params)
-    redirect_to new_medium_path, notice: 'Bulk upload job has been queued.'
+    if current_user.jobs.count < 10
+      MediaBulkUploadJob.enqueue(current_user, bulk_upload_params)
+      notice = 'Bulk upload job has been queued.'
+    else
+      notice = 'Up to 10 jobs can be registered. Please clear your jobs page.'
+    end
+
+    redirect_to new_medium_path, notice: notice
   end
 
   def destroy

--- a/app/views/media/jobs/_jobs_table.html.erb
+++ b/app/views/media/jobs/_jobs_table.html.erb
@@ -27,6 +27,9 @@
 			<td style="text-align:right"><%= message_counts[job.id] || 0 %></td>
 			<td>
 				<%= link_to 'Show', media_job_path(job), class: :button %>
+				<% unless job.running? %>
+					<%= link_to 'Remove', media_job_path(job), method: :delete, data: { confirm: t('controllers.shared.confirm_delete') }, class: :button %>
+				<% end %>
 			</td>
 		</tr>
 	<% end %>

--- a/app/views/media/jobs/index.html.erb
+++ b/app/views/media/jobs/index.html.erb
@@ -7,6 +7,8 @@
 <section>
 	<h2>Media Jobs</h2>
 
+	<%= link_to 'Clear finished jobs', media_clear_finished_jobs_path, method: :delete, data: { confirm: t('controllers.shared.confirm_delete') }, class: :button %>
+
 	<div class="jobs-table-wrapper">
 		<%= render partial: 'jobs_table', locals: { jobs: @jobs, message_counts: @job_message_counts, reload_necessary: @reload_necessary } %>
 	</div>

--- a/app/views/media/jobs/show.html.erb
+++ b/app/views/media/jobs/show.html.erb
@@ -9,6 +9,11 @@
 	<section>
 		<h1>
 		Job #<%= @job.id %>: <%= @job.name %>
+		<%=
+			unless @job.running?
+				link_to 'Remove', media_job_path(@job), method: :delete, data: { confirm: 'Are you sure?' }, :class => :button
+			end
+		%>
 		</h1>
 
 		<p id="notice"><%= notice %></p>

--- a/app/views/media/jobs/show.html.erb
+++ b/app/views/media/jobs/show.html.erb
@@ -9,11 +9,9 @@
 	<section>
 		<h1>
 		Job #<%= @job.id %>: <%= @job.name %>
-		<%=
-			unless @job.running?
-				link_to 'Remove', media_job_path(@job), method: :delete, data: { confirm: 'Are you sure?' }, :class => :button
-			end
-		%>
+		<% unless @job.running? %>
+			<%= link_to 'Remove', media_job_path(@job), method: :delete, data: { confirm: t('controllers.shared.confirm_delete') }, class: :button %>
+		<% end %>
 		</h1>
 
 		<p id="notice"><%= notice %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Pubann::Application.routes.draw do
 			post 'bulk_upload', to: 'media#bulk_upload'
 		end
 	end
+	delete 'media/jobs', to: 'media#clear_finished_jobs', as: :media_clear_finished_jobs
 	namespace :media do
 		resources :jobs, only: [:index, :show, :destroy] do
 			collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Pubann::Application.routes.draw do
 		end
 	end
 	namespace :media do
-		resources :jobs, only: [:index, :show] do
+		resources :jobs, only: [:index, :show, :destroy] do
 			collection do
 				get 'latest_jobs_table'
 			end

--- a/spec/controllers/media/jobs_controller_spec.rb
+++ b/spec/controllers/media/jobs_controller_spec.rb
@@ -142,4 +142,66 @@ RSpec.describe 'Media::JobsController', type: :request do
       end
     end
   end
+
+  describe 'DELETE /media/jobs/:id' do
+    context 'when the job is not running' do
+      let!(:job) { create(:job, :completed, organization: user) }
+
+      before { sign_in user }
+
+      it 'destroys the job and redirects to the media jobs page' do
+        expect {
+          delete media_job_path(job)
+        }.to change(Job, :count).by(-1)
+        expect(response).to redirect_to(media_jobs_path)
+      end
+    end
+
+    context 'when the job is running' do
+      let!(:job) { create(:job, organization: user) }
+
+      before { sign_in user }
+
+      it 'does not destroy the job' do
+        expect {
+          delete media_job_path(job)
+        }.not_to change(Job, :count)
+        expect(response).to redirect_to(media_jobs_path)
+      end
+    end
+
+    context "when logged in as a different user" do
+      let!(:job) { create(:job, :completed, organization: user) }
+
+      before { sign_in other_user }
+
+      it 'does not destroy the job' do
+        expect {
+          delete media_job_path(job)
+        }.not_to change(Job, :count)
+        expect(response).to redirect_to(media_jobs_path)
+      end
+    end
+
+    context 'when not logged in' do
+      let!(:job) { create(:job, :completed, organization: user) }
+
+      it 'redirects to login' do
+        delete media_job_path(job)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when logged in as a user who cannot access media' do
+      let(:restricted_user) { create(:user, can_use_media: false).tap { |u| u.confirm } }
+      let!(:job) { create(:job, :completed, organization: restricted_user) }
+
+      before { sign_in restricted_user }
+
+      it 'returns forbidden' do
+        delete media_job_path(job)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -157,11 +157,27 @@ RSpec.describe 'MediaController', type: :request do
     context 'when logged in' do
       before { sign_in user }
 
-      it 'enqueues a job and redirects to new medium page' do
-        expect {
-          post bulk_upload_media_path, params: { zip_file: zip_file }
-        }.to have_enqueued_job(MediaBulkUploadJob)
-        expect(response).to redirect_to(new_medium_path)
+      context 'when job count is under 10' do
+        it 'enqueues a job and redirects to new medium page' do
+          expect {
+            post bulk_upload_media_path, params: { zip_file: zip_file }
+          }.to have_enqueued_job(MediaBulkUploadJob)
+          expect(response).to redirect_to(new_medium_path)
+        end
+      end
+
+      context 'when job count is 10 or more' do
+        before do
+          10.times { create(:job, organization: user) }
+        end
+
+        it 'does not enqueue a job and redirects to new medium page with alert' do
+          expect {
+            post bulk_upload_media_path, params: { zip_file: zip_file }
+          }.not_to have_enqueued_job(MediaBulkUploadJob)
+          expect(response).to redirect_to(new_medium_path)
+          expect(flash[:notice]).to include('Up to 10 jobs')
+        end
       end
     end
 

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe 'MediaController', type: :request do
           10.times { create(:job, organization: user) }
         end
 
-        it 'does not enqueue a job and redirects to new medium page with alert' do
+        it 'does not enqueue a job and redirects to new medium page with notice' do
           expect {
             post bulk_upload_media_path, params: { zip_file: zip_file }
           }.not_to have_enqueued_job(MediaBulkUploadJob)

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -188,4 +188,42 @@ RSpec.describe 'MediaController', type: :request do
       end
     end
   end
+
+  describe 'DELETE /media/jobs' do
+    context 'when logged in' do
+      before { sign_in user }
+
+      it 'destroys finished jobs but keeps unfinished ones' do
+        finished_job = create(:job, :completed, organization: user)
+        unfinished_job = create(:job, organization: user)
+
+        expect {
+          delete media_clear_finished_jobs_path
+        }.to change(Job, :count).by(-1)
+
+        expect(Job.exists?(finished_job.id)).to be false
+        expect(Job.exists?(unfinished_job.id)).to be true
+        expect(response).to redirect_to(media_jobs_path)
+        expect(flash[:notice]).to eq('Finished jobs cleared.')
+      end
+    end
+
+    context 'when not logged in' do
+      it 'redirects to login' do
+        delete media_clear_finished_jobs_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when logged in as a user who cannot access media' do
+      let(:restricted_user) { create(:user, can_use_media: false).tap { |u| u.confirm } }
+
+      before { sign_in restricted_user }
+
+      it 'returns forbidden' do
+        delete media_clear_finished_jobs_path
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

#25 の分割PRの一つです。

- Media job の削除（Remove）ボタンを一覧・詳細ページに追加
- 完了済みジョブの一括削除（Clear finished jobs）を追加
- 同時に登録できるジョブ数を10件に制限し、上限到達時はアップロードをブロックしてメッセージを表示

## 動作確認

- 追加分を含むすべてのspecがパスすることを確認
- 削除機能が機能することを確認
- Jobが10件ある場合は追加でJobを作成できないことを確認