### PR TITLE
Add message list and detail pages for media jobs

### DIFF
--- a/app/controllers/media/jobs_controller.rb
+++ b/app/controllers/media/jobs_controller.rb
@@ -12,6 +12,11 @@ class Media::JobsController < ApplicationController
   end
 
   def show
+    @messages_grid = initialize_grid(@job.messages,
+      order: :created_at,
+      order_direction: :desc,
+      per_page: 10
+    )
   end
 
   def latest_jobs_table

--- a/app/controllers/media/messages_controller.rb
+++ b/app/controllers/media/messages_controller.rb
@@ -1,0 +1,25 @@
+class Media::MessagesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :authorize_media_access!
+  before_action :set_message
+
+  rescue_from ActiveRecord::RecordNotFound do
+    redirect_to media_jobs_path, notice: 'Could not find the message.'
+  end
+
+  def show
+  end
+
+  private
+
+  def set_message
+    @job = current_user.jobs.find(params[:job_id])
+    @message = @job.messages.find(params[:id])
+  end
+
+  def authorize_media_access!
+    unless current_user&.can_access_media?
+      render_status_error(:forbidden)
+    end
+  end
+end

--- a/app/views/media/jobs/_messages_grid.html.erb
+++ b/app/views/media/jobs/_messages_grid.html.erb
@@ -1,0 +1,33 @@
+<% if @job.messages.present? %>
+	<section>
+		<h2>Problem report</h2>
+
+		<%=
+			grid(@messages_grid) do |g|
+
+				g.column name: 'sourcedb', attribute: 'sourcedb' do |message|
+					[message.sourcedb, {style: 'width:7em; text-align:center'}]
+				end
+
+				g.column name: 'sourceid', attribute: 'sourceid' do |message|
+					[(message.sourcedb && message.sourceid) ? link_to(message.sourceid, show_media_path(sourcedb: message.sourcedb, sourceid: message.sourceid), style:'display:block') : message.sourceid, {style: 'width:7em; text-align:center'}]
+				end
+
+				g.column name: 'divid', attribute: 'divid' do |message|
+					[message.divid, {style: 'width:3em; text-align:right'}]
+				end
+
+				g.column name: 'message', attribute: 'body' do |message|
+					[link_to(message.body, media_job_message_path(@job, message)), {title: message.body, style: 'width:20em; max-width: 20em; white-space:initial; overflow:hidden; text-overflow:ellipsis'}]
+				end
+
+				g.column name: 'reported at', attribute: 'updated_at' do |message|
+					[message.updated_at, {style: 'width:14em; text-align:center'}]
+				end
+
+			end
+		-%>
+
+	</section>
+
+<% end %>

--- a/app/views/media/jobs/show.html.erb
+++ b/app/views/media/jobs/show.html.erb
@@ -72,5 +72,7 @@
 			<% end %>
 		<% end %>
 		</table>
+
+		<%= render partial: 'messages_grid' -%>
 	</section>
 </section>

--- a/app/views/media/messages/show.html.erb
+++ b/app/views/media/messages/show.html.erb
@@ -1,0 +1,16 @@
+<section>
+	<h1>Message</h1>
+	<%= @message.body %>
+
+	<section>
+		<h2>Job</h2>
+		<%= @job.name %>
+	</section>
+
+	<% if @message.sourcedb && @message.sourceid %>
+		<section>
+			<h2>Document</h2>
+			<%= link_to "#{@message.sourcedb}:#{@message.sourceid}", show_media_path(sourcedb: @message.sourcedb, sourceid: @message.sourceid) %>
+		</section>
+	<% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Pubann::Application.routes.draw do
 			collection do
 				get 'latest_jobs_table'
 			end
+			resources :messages, only: [:show]
 		end
 	end
 

--- a/spec/controllers/media/jobs_controller_spec.rb
+++ b/spec/controllers/media/jobs_controller_spec.rb
@@ -93,6 +93,15 @@ RSpec.describe 'Media::JobsController', type: :request do
 
         expect(response).to have_http_status(:ok)
       end
+
+      it 'shows a link to each message' do
+        job.add_message(sourcedb: 'PMC', sourceid: '1', body: 'something went wrong')
+        message = job.messages.last
+
+        get media_job_path(job)
+
+        expect(response.body).to include(media_job_message_path(job, message))
+      end
     end
 
     context "when logged in as a different user" do

--- a/spec/controllers/media/messages_controller_spec.rb
+++ b/spec/controllers/media/messages_controller_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Media::MessagesController', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user).tap { |u| u.confirm } }
+  let(:other_user) { create(:user).tap { |u| u.confirm } }
+  let(:job) { create(:job, organization: user) }
+  let!(:message) do
+    job.add_message(sourcedb: 'PMC', sourceid: '1', body: 'something went wrong')
+    job.messages.last
+  end
+
+  describe 'GET /media/jobs/:job_id/messages/:id' do
+    context 'when logged in as the job owner' do
+      before { sign_in user }
+
+      it 'renders the show page' do
+        get media_job_message_path(job, message)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when logged in as a different user' do
+      before { sign_in other_user }
+
+      it 'redirects to the media jobs page' do
+        get media_job_message_path(job, message)
+        expect(response).to redirect_to(media_jobs_path)
+        expect(flash[:notice]).to eq('Could not find the message.')
+      end
+    end
+
+    context 'when the message does not exist' do
+      before { sign_in user }
+
+      it 'redirects to the media jobs page' do
+        get media_job_message_path(job, id: 'does-not-exist')
+        expect(response).to redirect_to(media_jobs_path)
+      end
+    end
+
+    context 'when not logged in' do
+      it 'redirects to login' do
+        get media_job_message_path(job, message)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when logged in as a user who cannot access media' do
+      let(:restricted_user) { create(:user, can_use_media: false).tap { |u| u.confirm } }
+      let(:job) { create(:job, organization: restricted_user) }
+
+      before { sign_in restricted_user }
+
+      it 'returns forbidden' do
+        get media_job_message_path(job, message)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

https://github.com/pubannotation/pubannotation/pull/275#discussion_r3556779321

このコメントの対応

- メディアのメッセージ専用のコントローラーを追加(`app/controllers/media/messages_controller.rb`)
- Jobのメッセージ一覧、詳細画面を確認できるようにする機能の実装を行いました。

## 動作確認

- 追加分を含む全てのspecがパスすることを確認しました。
- 作成したJobのメッセージ一覧、メッセージ詳細がブラウザで表示できることを確認しました。