### PR TITLE
Extract authorize_media_access! into a shared concern

### DIFF
--- a/app/controllers/concerns/media_access_authorization_concern.rb
+++ b/app/controllers/concerns/media_access_authorization_concern.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module MediaAccessAuthorizationConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  def authorize_media_access!
+    unless current_user&.can_access_media?
+      render_status_error(:forbidden)
+    end
+  end
+end

--- a/app/controllers/media/jobs_controller.rb
+++ b/app/controllers/media/jobs_controller.rb
@@ -1,4 +1,6 @@
 class Media::JobsController < ApplicationController
+  include MediaAccessAuthorizationConcern
+
   before_action :authenticate_user!
   before_action :authorize_media_access!
   before_action :set_job, only: [:show]
@@ -34,12 +36,6 @@ class Media::JobsController < ApplicationController
 
   def set_job
     @job = current_user.jobs.find(params[:id])
-  end
-
-  def authorize_media_access!
-    unless current_user&.can_access_media?
-      render_status_error(:forbidden)
-    end
   end
 
   def message_counts_for(jobs)

--- a/app/controllers/media/messages_controller.rb
+++ b/app/controllers/media/messages_controller.rb
@@ -1,4 +1,6 @@
 class Media::MessagesController < ApplicationController
+  include MediaAccessAuthorizationConcern
+
   before_action :authenticate_user!
   before_action :authorize_media_access!
   before_action :set_message
@@ -15,11 +17,5 @@ class Media::MessagesController < ApplicationController
   def set_message
     @job = current_user.jobs.find(params[:job_id])
     @message = @job.messages.find(params[:id])
-  end
-
-  def authorize_media_access!
-    unless current_user&.can_access_media?
-      render_status_error(:forbidden)
-    end
   end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,5 +1,6 @@
 class MediaController < ApplicationController
   include MediumHelper
+  include MediaAccessAuthorizationConcern
 
   before_action :authenticate_user!
   before_action :authorize_media_access!
@@ -43,12 +44,6 @@ class MediaController < ApplicationController
 
   def bulk_upload_params
     params.expect(:zip_file)
-  end
-
-  def authorize_media_access!
-    unless current_user&.can_access_media?
-      render_status_error(:forbidden)
-    end
   end
 
   def set_medium


### PR DESCRIPTION
## 概要

https://github.com/pubannotation/pubannotation/pull/279#discussion_r3575666555

こちらのコメントの対応

app/controllers/concerns/media_access_authorization_concern.rbを作成し、メディア関連の権限のチェックをこのconcernで行うようにしました。

## 動作確認

- 既存specがすべてパスすることを確認
- media権限のない一般ユーザーでログイン時、media配下のパスで403エラーが出ることを確認
  - http://localhost:3000/media/
  - http://localhost:3000/media/jobs