### PR TITLE
Add doc generation from media (basic flow)

### DIFF
--- a/app/controllers/doc_generations_controller.rb
+++ b/app/controllers/doc_generations_controller.rb
@@ -3,7 +3,7 @@ class DocGenerationsController < ApplicationController
 
   before_action :authenticate_user!
   before_action :authorize_media_access!
-  before_action :set_editable_project
+  before_action :ensure_editable_project!
 
   def new
   end
@@ -40,11 +40,16 @@ class DocGenerationsController < ApplicationController
     params.permit(:source, :sourcedb, :sourceid).to_h.symbolize_keys
   end
 
-  def set_editable_project
-    @project = Project.editable(current_user).find_by_name(params[:project_id])
-    return if @project.present?
+  def ensure_editable_project!
+    @project = Project.editable(current_user).find_by(name: params.expect(:project_id))
+    return if @project
 
+    render_project_not_found
+  end
+
+  def render_project_not_found
     message = "The project does not exist, or you are not authorized to make a change to the project."
+
     respond_to do |format|
       format.html { redirect_to home_path, notice: message }
       format.json { render json: { message: message }, status: :not_found }

--- a/app/controllers/doc_generations_controller.rb
+++ b/app/controllers/doc_generations_controller.rb
@@ -1,0 +1,45 @@
+class DocGenerationsController < ApplicationController
+  include MediaAccessAuthorizationConcern
+
+  before_action :authenticate_user!
+  before_action :authorize_media_access!
+  before_action :set_editable_project
+
+  def new
+  end
+
+  def create
+    medium = Medium.find_by(sourcedb: params.dig(:media, :sourcedb), sourceid: params.dig(:media, :sourceid))
+    raise ArgumentError, "Specified media does not exist." unless medium
+
+    @doc = DocGenerationFromMedia.new(
+      project: @project,
+      medium: medium,
+      user: current_user,
+      attributes: { source: params[:source], sourcedb: params[:sourcedb], sourceid: params[:sourceid] }
+    ).call
+
+    respond_to do |format|
+      format.html { redirect_to show_project_sourcedb_sourceid_docs_path(@project.name, @doc.sourcedb, @doc.sourceid), notice: t('controllers.shared.successfully_created', model: t('activerecord.models.doc')) }
+      format.json { render json: @doc.to_hash, status: :created, location: @doc }
+    end
+  rescue => e
+    respond_to do |format|
+      format.html { redirect_to new_project_doc_generation_path(@project.name), notice: e.message }
+      format.json { render json: { message: e.message }, status: :unprocessable_entity }
+    end
+  end
+
+  private
+
+  def set_editable_project
+    @project = Project.editable(current_user).find_by_name(params[:project_id])
+    return if @project.present?
+
+    message = "The project does not exist, or you are not authorized to make a change to the project."
+    respond_to do |format|
+      format.html { redirect_to home_path, notice: message }
+      format.json { render json: { message: message }, status: :unprocessable_entity }
+    end
+  end
+end

--- a/app/controllers/doc_generations_controller.rb
+++ b/app/controllers/doc_generations_controller.rb
@@ -47,7 +47,7 @@ class DocGenerationsController < ApplicationController
     message = "The project does not exist, or you are not authorized to make a change to the project."
     respond_to do |format|
       format.html { redirect_to home_path, notice: message }
-      format.json { render json: { message: message }, status: :unprocessable_entity }
+      format.json { render json: { message: message }, status: :not_found }
     end
   end
 end

--- a/app/controllers/doc_generations_controller.rb
+++ b/app/controllers/doc_generations_controller.rb
@@ -23,7 +23,7 @@ class DocGenerationsController < ApplicationController
       format.html { redirect_to show_project_sourcedb_sourceid_docs_path(@project.name, @doc.sourcedb, @doc.sourceid), notice: t('controllers.shared.successfully_created', model: t('activerecord.models.doc')) }
       format.json { render json: @doc.to_hash, status: :created, location: @doc }
     end
-  rescue => e
+  rescue ArgumentError => e
     respond_to do |format|
       format.html { redirect_to new_project_doc_generation_path(@project.name), notice: e.message }
       format.json { render json: { message: e.message }, status: :unprocessable_entity }

--- a/app/controllers/doc_generations_controller.rb
+++ b/app/controllers/doc_generations_controller.rb
@@ -24,10 +24,7 @@ class DocGenerationsController < ApplicationController
       format.json { render json: @doc.to_hash, status: :created, location: @doc }
     end
   rescue ArgumentError => e
-    respond_to do |format|
-      format.html { redirect_to new_project_doc_generation_path(@project.name), notice: e.message }
-      format.json { render json: { message: e.message }, status: :unprocessable_entity }
-    end
+    render_error(message: e.message, status: :unprocessable_entity)
   end
 
   private
@@ -48,11 +45,17 @@ class DocGenerationsController < ApplicationController
   end
 
   def render_project_not_found
-    message = "The project does not exist, or you are not authorized to make a change to the project."
+    render_error(
+      message: "The project does not exist, or you are not authorized to make a change to the project.",
+      status: :not_found,
+      redirect_path: home_path
+    )
+  end
 
+  def render_error(message:, status:, redirect_path: new_project_doc_generation_path(@project.name))
     respond_to do |format|
-      format.html { redirect_to home_path, notice: message }
-      format.json { render json: { message: message }, status: :not_found }
+      format.html { redirect_to redirect_path, notice: message }
+      format.json { render json: { message: message }, status: status }
     end
   end
 end

--- a/app/controllers/doc_generations_controller.rb
+++ b/app/controllers/doc_generations_controller.rb
@@ -9,14 +9,14 @@ class DocGenerationsController < ApplicationController
   end
 
   def create
-    medium = Medium.find_by(sourcedb: params.dig(:media, :sourcedb), sourceid: params.dig(:media, :sourceid))
+    medium = Medium.find_by(media_params)
     raise ArgumentError, "Specified media does not exist." unless medium
 
     @doc = DocGenerationFromMedia.new(
       project: @project,
       medium: medium,
       user: current_user,
-      attributes: { source: params[:source], sourcedb: params[:sourcedb], sourceid: params[:sourceid] }
+      attributes: doc_attributes
     ).call
 
     respond_to do |format|
@@ -31,6 +31,14 @@ class DocGenerationsController < ApplicationController
   end
 
   private
+
+  def media_params
+    params.expect(media: [:sourcedb, :sourceid]).to_h.symbolize_keys
+  end
+
+  def doc_attributes
+    params.permit(:source, :sourcedb, :sourceid).to_h.symbolize_keys
+  end
 
   def set_editable_project
     @project = Project.editable(current_user).find_by_name(params[:project_id])

--- a/app/services/doc_generation_from_media.rb
+++ b/app/services/doc_generation_from_media.rb
@@ -1,0 +1,38 @@
+class DocGenerationFromMedia
+  def initialize(project:, medium:, user:, attributes:)
+    @project = project
+    @medium = medium
+    @user = user
+    @attributes = attributes
+  end
+
+  def call
+    validate_medium!
+
+    caption = @medium.file.open do |file|
+      ImageCaptionService.new(file.path).call
+    end
+
+    hdoc = Doc.hdoc_normalize!(
+      {
+        **@attributes,
+        username: @user.username,
+        body: caption,
+        medium_id: @medium.id
+      },
+      @user,
+      @user.root?
+    )
+
+    doc = Doc.store_hdoc!(hdoc)
+    @project.add_doc!(doc)
+    doc
+  end
+
+  private
+
+  def validate_medium!
+    raise ArgumentError, "Text generation is supported only for image media." unless @medium.image?
+    raise ArgumentError, "Specified media has no attached file." unless @medium.file.attached?
+  end
+end

--- a/app/views/doc_generations/new.html.erb
+++ b/app/views/doc_generations/new.html.erb
@@ -1,0 +1,58 @@
+<% content_for :path do -%>
+	> <%= link_to t('views.paths.home'), home_path -%>
+	> <%= link_to t('activerecord.models.project').pluralize, projects_path -%>
+	> <%= link_to @project.name, project_path(@project.name) -%>
+	> <%= link_to "docs", project_docs_path(@project.name) %>
+	> new from media
+<% end -%>
+
+<section>
+	<%= render partial: 'projects/titlebar' -%>
+
+	<section>
+		<h2>Generate a new document from media</h2>
+
+		<%= form_tag project_doc_generations_path(@project.name) do %>
+			<table style="width:610px">
+				<tr>
+					<th>Media</th>
+					<td>
+						<table>
+							<tr>
+								<th>Media Source DB</th>
+								<td><%= text_field_tag 'media[sourcedb]' %></td>
+							</tr>
+							<tr>
+								<th>Media Source Id</th>
+								<td><%= text_field_tag 'media[sourceid]' %></td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+				<tr>
+					<th>Meta-data</th>
+					<td>
+						<table>
+							<tr>
+								<th>Source URL</th>
+								<td><%= text_field_tag :source %></td>
+							</tr>
+							<tr>
+								<th>Source DB</th>
+								<td><%= text_field_tag :sourcedb %></td>
+							</tr>
+							<tr>
+								<th>Source Id</th>
+								<td><%= text_field_tag :sourceid %></td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+			</table>
+
+			<div class="actions">
+				<%= submit_tag 'Generate & Create' %>
+			</div>
+		<% end %>
+	</section>
+</section>

--- a/app/views/doc_generations/new.html.erb
+++ b/app/views/doc_generations/new.html.erb
@@ -20,11 +20,11 @@
 						<table>
 							<tr>
 								<th>Media Source DB</th>
-								<td><%= text_field_tag 'media[sourcedb]' %></td>
+								<td><%= text_field_tag 'media[sourcedb]', nil, required: true %></td>
 							</tr>
 							<tr>
 								<th>Media Source Id</th>
-								<td><%= text_field_tag 'media[sourceid]' %></td>
+								<td><%= text_field_tag 'media[sourceid]', nil, required: true %></td>
 							</tr>
 						</table>
 					</td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,6 +201,8 @@ Pubann::Application.routes.draw do
 
 		resources :evaluations
 
+		resources :doc_generations, only: [:new, :create]
+
 		resources :docs do
 			collection do
 				get 'index' => 'docs#index'

--- a/spec/requests/doc_generations_spec.rb
+++ b/spec/requests/doc_generations_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'DocGenerationsController', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user).tap { |u| u.confirm } }
+  let(:project) { create(:project, user: user) }
+  let(:image_medium) do
+    medium = create(:medium)
+    medium.file.attach(
+      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_image.png')),
+      filename: 'test_image.png',
+      content_type: 'image/png'
+    )
+    medium
+  end
+
+  before do
+    allow(Elasticsearch::IndexQueue).to receive(:index_doc)
+    allow(Elasticsearch::IndexQueue).to receive(:delete_doc)
+    allow(Elasticsearch::IndexQueue).to receive(:update_embedding)
+  end
+
+  describe 'GET /projects/:project_id/doc_generations/new' do
+    it 'renders the form' do
+      sign_in user
+      get new_project_doc_generation_path(project.name)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /projects/:project_id/doc_generations' do
+    before { sign_in user }
+
+    it 'uses the generated caption as the body and links the medium' do
+      allow(ImageCaptionService).to receive(:new).and_return(instance_double(ImageCaptionService, call: 'A generated caption.'))
+
+      post project_doc_generations_path(project.name),
+           params: { media: { sourcedb: image_medium.sourcedb, sourceid: image_medium.sourceid }, sourcedb: 'Example', sourceid: '001' }
+
+      expect(response).to redirect_to(show_project_sourcedb_sourceid_docs_path(project.name, "Example@#{user.username}", '001'))
+      doc = Doc.last
+      expect(doc.body).to eq('A generated caption.')
+      expect(doc.medium).to eq(image_medium)
+    end
+
+    it 'returns an error when the specified medium does not exist' do
+      expect {
+        post project_doc_generations_path(project.name),
+             params: { media: { sourcedb: 'NonExistentDB', sourceid: 'nonexistent-001' } }
+      }.not_to change(Doc, :count)
+
+      expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+    end
+
+    it 'returns an error when the medium is not an image' do
+      video_medium = create(:medium, media_type: :video, content_type: 'video/mp4')
+
+      expect {
+        post project_doc_generations_path(project.name),
+             params: { media: { sourcedb: video_medium.sourcedb, sourceid: video_medium.sourceid } }
+      }.not_to change(Doc, :count)
+
+      expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+    end
+
+    it 'returns an error when the medium has no attached file' do
+      medium_without_file = create(:medium)
+
+      expect {
+        post project_doc_generations_path(project.name),
+             params: { media: { sourcedb: medium_without_file.sourcedb, sourceid: medium_without_file.sourceid } }
+      }.not_to change(Doc, :count)
+
+      expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+    end
+  end
+end


### PR DESCRIPTION
## 概要

- #268 から、実装一式＋最小限のspec5件を分離しました。
- specの強化とUIの動線、localeの追加は次のPRで行う予定です。
- 最終的に  #268 は手動でcloseするつもりです。

<img width="1048" height="618" alt="スクリーンショット 2026-07-21 12 04 30" src="https://github.com/user-attachments/assets/de3a826c-8c92-4e50-81df-aee6a56f5631" />

## 動作確認

- 追加分を含むspecがパスすることを確認
- `/projects/:project_id/doc_generations/new` にアクセスしてフォームが表示されることを確認
  - 例: http://localhost:3000/projects/PubMed_Project/doc_generations/new
- フォームに入力が必要な項目を入力してボタンを押下すると、キャプションが生成されたDocの詳細画面に遷移すること