### PR TITLE
Doc generation hardening

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -95,6 +95,12 @@
 				<th><%= t('views.shared.create') %></th>
 				<td><%= link_to t('views.docs.create_doc'), new_project_doc_path(@project.name), class: 'button long_button' -%></td>
 			</tr>
+			<% if current_user&.can_access_media? %>
+				<tr>
+					<th></th>
+					<td><%= link_to t('views.docs.create_doc_from_media'), new_project_doc_generation_path(@project.name), class: 'button long_button' -%></td>
+				</tr>
+			<% end %>
 			<tr>
 				<th><%= t('views.shared.upload') %></th>
 				<td><%= link_to t('views.docs.upload_docs'), upload_docs_project_path(@project.name), class: 'button long_button' -%></td>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -92,12 +92,11 @@
 				<td style="text-align:right"><%= render partial: 'import_docs_form' -%></td>
 			</tr>
 			<tr>
-				<th><%= t('views.shared.create') %></th>
+				<%= tag.th t('views.shared.create'), rowspan: (current_user&.can_access_media? ? 2 : nil) %>
 				<td><%= link_to t('views.docs.create_doc'), new_project_doc_path(@project.name), class: 'button long_button' -%></td>
 			</tr>
 			<% if current_user&.can_access_media? %>
 				<tr>
-					<th></th>
 					<td><%= link_to t('views.docs.create_doc_from_media'), new_project_doc_generation_path(@project.name), class: 'button long_button' -%></td>
 				</tr>
 			<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -463,6 +463,7 @@ en:
       add_docs: Add documents
       import_docs: Import documents
       create_doc: Create a new document
+      create_doc_from_media: Generate a new document from media
       upload_docs: Upload documents
       rdfize_annotations: RDFize annotations
       rdfize_spans: RDFize spans

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -444,6 +444,7 @@ ja:
       add_docs: ドキュメント追加
       import_docs: ドキュメントインポート
       create_doc: ドキュメント新規作成
+      create_doc_from_media: メディアからドキュメントを生成
       upload_docs: ドキュメントアップロード
       create_a_new_document: ドキュメント生成
       rdfize_annotations: アノテーションのRDF化

--- a/spec/requests/doc_generations_spec.rb
+++ b/spec/requests/doc_generations_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'DocGenerationsController', type: :request do
           post project_doc_generations_path(project.name), params: {}
         }.not_to change(Doc, :count)
 
-        expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+        expect(response).to have_http_status(:bad_request)
       end
 
       it 'returns an error when only the media sourcedb is specified' do
@@ -175,7 +175,7 @@ RSpec.describe 'DocGenerationsController', type: :request do
         post project_doc_generations_path('nonexistent-project', format: :json),
              params: { media: { sourcedb: image_medium.sourcedb, sourceid: image_medium.sourceid } }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/doc_generations_spec.rb
+++ b/spec/requests/doc_generations_spec.rb
@@ -24,57 +24,159 @@ RSpec.describe 'DocGenerationsController', type: :request do
   end
 
   describe 'GET /projects/:project_id/doc_generations/new' do
-    it 'renders the form' do
-      sign_in user
-      get new_project_doc_generation_path(project.name)
-      expect(response).to have_http_status(:ok)
+    context 'when logged in' do
+      before { sign_in user }
+
+      it 'renders the form' do
+        get new_project_doc_generation_path(project.name)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not logged in' do
+      it 'redirects to login' do
+        get new_project_doc_generation_path(project.name)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when logged in as a user who cannot access media' do
+      let(:restricted_user) { create(:user, can_use_media: false).tap { |u| u.confirm } }
+      let(:restricted_project) { create(:project, user: restricted_user) }
+
+      before { sign_in restricted_user }
+
+      it 'returns forbidden' do
+        get new_project_doc_generation_path(restricted_project.name)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when the project does not exist' do
+      before { sign_in user }
+
+      it 'redirects to home' do
+        get new_project_doc_generation_path('nonexistent-project')
+        expect(response).to redirect_to(home_path)
+      end
     end
   end
 
   describe 'POST /projects/:project_id/doc_generations' do
-    before { sign_in user }
+    context 'when logged in' do
+      before { sign_in user }
 
-    it 'uses the generated caption as the body and links the medium' do
-      allow(ImageCaptionService).to receive(:new).and_return(instance_double(ImageCaptionService, call: 'A generated caption.'))
+      it 'uses the generated caption as the body and links the medium' do
+        allow(ImageCaptionService).to receive(:new).and_return(instance_double(ImageCaptionService, call: 'A generated caption.'))
 
-      post project_doc_generations_path(project.name),
-           params: { media: { sourcedb: image_medium.sourcedb, sourceid: image_medium.sourceid }, sourcedb: 'Example', sourceid: '001' }
+        post project_doc_generations_path(project.name),
+             params: { media: { sourcedb: image_medium.sourcedb, sourceid: image_medium.sourceid }, sourcedb: 'Example', sourceid: '001' }
 
-      expect(response).to redirect_to(show_project_sourcedb_sourceid_docs_path(project.name, "Example@#{user.username}", '001'))
-      doc = Doc.last
-      expect(doc.body).to eq('A generated caption.')
-      expect(doc.medium).to eq(image_medium)
+        expect(response).to redirect_to(show_project_sourcedb_sourceid_docs_path(project.name, "Example@#{user.username}", '001'))
+        doc = Doc.last
+        expect(doc.body).to eq('A generated caption.')
+        expect(doc.sourcedb).to eq("Example@#{user.username}")
+        expect(doc.sourceid).to eq('001')
+        expect(doc.medium).to eq(image_medium)
+      end
+
+      it 'returns an error when no media is specified' do
+        expect {
+          post project_doc_generations_path(project.name), params: {}
+        }.not_to change(Doc, :count)
+
+        expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+      end
+
+      it 'returns an error when only the media sourcedb is specified' do
+        expect {
+          post project_doc_generations_path(project.name),
+               params: { media: { sourcedb: image_medium.sourcedb, sourceid: '' } }
+        }.not_to change(Doc, :count)
+
+        expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+      end
+
+      it 'returns an error when only the media sourceid is specified' do
+        expect {
+          post project_doc_generations_path(project.name),
+               params: { media: { sourcedb: '', sourceid: image_medium.sourceid } }
+        }.not_to change(Doc, :count)
+
+        expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+      end
+
+      it 'returns an error when the specified medium does not exist' do
+        expect {
+          post project_doc_generations_path(project.name),
+               params: { media: { sourcedb: 'NonExistentDB', sourceid: 'nonexistent-001' } }
+        }.not_to change(Doc, :count)
+
+        expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+      end
+
+      it 'returns an error when the medium is not an image' do
+        video_medium = create(:medium, media_type: :video, content_type: 'video/mp4')
+
+        expect {
+          post project_doc_generations_path(project.name),
+               params: { media: { sourcedb: video_medium.sourcedb, sourceid: video_medium.sourceid } }
+        }.not_to change(Doc, :count)
+
+        expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+      end
+
+      it 'returns an error when the medium has no attached file' do
+        medium_without_file = create(:medium)
+
+        expect {
+          post project_doc_generations_path(project.name),
+               params: { media: { sourcedb: medium_without_file.sourcedb, sourceid: medium_without_file.sourceid } }
+        }.not_to change(Doc, :count)
+
+        expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+      end
     end
 
-    it 'returns an error when the specified medium does not exist' do
-      expect {
-        post project_doc_generations_path(project.name),
-             params: { media: { sourcedb: 'NonExistentDB', sourceid: 'nonexistent-001' } }
-      }.not_to change(Doc, :count)
+    context 'when logged in as a user who cannot access media' do
+      let(:restricted_user) { create(:user, can_use_media: false).tap { |u| u.confirm } }
+      let(:restricted_project) { create(:project, user: restricted_user) }
 
-      expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+      before { sign_in restricted_user }
+
+      it 'returns forbidden' do
+        expect {
+          post project_doc_generations_path(restricted_project.name),
+               params: { media: { sourcedb: image_medium.sourcedb, sourceid: image_medium.sourceid } }
+        }.not_to change(Doc, :count)
+
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
-    it 'returns an error when the medium is not an image' do
-      video_medium = create(:medium, media_type: :video, content_type: 'video/mp4')
-
-      expect {
+    context 'when not logged in' do
+      it 'redirects to login' do
         post project_doc_generations_path(project.name),
-             params: { media: { sourcedb: video_medium.sourcedb, sourceid: video_medium.sourceid } }
-      }.not_to change(Doc, :count)
-
-      expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+             params: { media: { sourcedb: image_medium.sourcedb, sourceid: image_medium.sourceid } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
     end
 
-    it 'returns an error when the medium has no attached file' do
-      medium_without_file = create(:medium)
+    context 'when the project does not exist' do
+      before { sign_in user }
 
-      expect {
-        post project_doc_generations_path(project.name),
-             params: { media: { sourcedb: medium_without_file.sourcedb, sourceid: medium_without_file.sourceid } }
-      }.not_to change(Doc, :count)
+      it 'redirects to home for HTML requests' do
+        post project_doc_generations_path('nonexistent-project'),
+             params: { media: { sourcedb: image_medium.sourcedb, sourceid: image_medium.sourceid } }
+        expect(response).to redirect_to(home_path)
+      end
 
-      expect(response).to redirect_to(new_project_doc_generation_path(project.name))
+      it 'returns an error for JSON requests' do
+        post project_doc_generations_path('nonexistent-project', format: :json),
+             params: { media: { sourcedb: image_medium.sourcedb, sourceid: image_medium.sourceid } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 end

--- a/spec/services/doc_generation_from_media_spec.rb
+++ b/spec/services/doc_generation_from_media_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DocGenerationFromMedia do
+  let(:user) { create(:user).tap { |u| u.confirm } }
+  let(:project) { create(:project, user: user) }
+  let(:image_medium) do
+    medium = create(:medium)
+    medium.file.attach(
+      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_image.png')),
+      filename: 'test_image.png',
+      content_type: 'image/png'
+    )
+    medium
+  end
+
+  describe '#call' do
+    context 'with a valid image medium' do
+      before do
+        allow(ImageCaptionService).to receive(:new).and_return(instance_double(ImageCaptionService, call: 'A generated caption.'))
+      end
+
+      it 'creates a doc with the generated caption, linked to the medium and the project' do
+        doc = described_class.new(
+          project: project,
+          medium: image_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '001' }
+        ).call
+
+        expect(doc).to be_persisted
+        expect(doc.body).to eq('A generated caption.')
+        expect(doc.sourcedb).to eq("Example@#{user.username}")
+        expect(doc.sourceid).to eq('001')
+        expect(doc.medium).to eq(image_medium)
+        expect(project.docs).to include(doc)
+      end
+    end
+
+    context 'when the medium is not an image' do
+      let(:video_medium) { create(:medium, media_type: :video, content_type: 'video/mp4') }
+
+      it 'raises without creating a doc' do
+        expect {
+          described_class.new(
+            project: project,
+            medium: video_medium,
+            user: user,
+            attributes: { source: nil, sourcedb: nil, sourceid: nil }
+          ).call
+        }.to raise_error(ArgumentError, /image media/).and change(Doc, :count).by(0)
+      end
+    end
+
+    context 'when the medium has no attached file' do
+      let(:medium_without_file) { create(:medium) }
+
+      it 'raises without creating a doc' do
+        expect {
+          described_class.new(
+            project: project,
+            medium: medium_without_file,
+            user: user,
+            attributes: { source: nil, sourcedb: nil, sourceid: nil }
+          ).call
+        }.to raise_error(ArgumentError, /no attached file/).and change(Doc, :count).by(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

- #268 からspecの強化とフォームへの導線の追加、localeの追加を分離しました。
- 最終的に  #268 は手動でcloseするつもりです。

<img width="1019" height="565" alt="スクリーンショット 2026-07-22 17 39 52" src="https://github.com/user-attachments/assets/b15295ea-e4d4-47e6-950d-5bbe8352824f" />


## 動作確認

- 追加分を含む全てのspecがパスすることを確認
- mediaからdocを生成するためのフォームへの導線がProjectメニューの中に追加されていることを確認
  - 例: http://localhost:3000/projects/PubMed_Project