### PR TITLE
Media bulk upload support video audio

### DIFF
--- a/app/services/medium_upload_entry_parser.rb
+++ b/app/services/medium_upload_entry_parser.rb
@@ -4,7 +4,12 @@ class MediumUploadEntryParser
     '.jpeg' => [:image, 'image/jpeg'],
     '.png' => [:image, 'image/png'],
     '.gif' => [:image, 'image/gif'],
-    '.webp' => [:image, 'image/webp']
+    '.webp' => [:image, 'image/webp'],
+    '.mp4' => [:video, 'video/mp4'],
+    '.webm' => [:video, 'video/webm'],
+    '.mp3' => [:audio, 'audio/mpeg'],
+    '.wav' => [:audio, 'audio/wav'],
+    '.ogg' => [:audio, 'audio/ogg']
   }.freeze
 
   def self.call(entry)

--- a/spec/services/medium_bulk_upload_service_spec.rb
+++ b/spec/services/medium_bulk_upload_service_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe MediumBulkUploadService do
   let(:user) { create(:user).tap { |u| u.confirm } }
   let(:png_data) { File.binread(Rails.root.join('spec', 'fixtures', 'files', 'test_image.png')) }
+  let(:mp4_data) { File.binread(Rails.root.join('spec', 'fixtures', 'files', 'test_video.mp4')) }
+  let(:mp3_data) { File.binread(Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3')) }
 
   def build_zip(entries)
     Tempfile.new(['test', '.zip']).tap do |zip_file|
@@ -54,6 +56,27 @@ RSpec.describe MediumBulkUploadService do
         results = collect_results(described_class.new(zip_file.path, user))
         expect(results.count { |r| r.status == :success }).to eq(1)
         expect(results.none? { |r| r.status == :error }).to be true
+      end
+    end
+
+    context 'with valid video and audio files' do
+      let(:zip_file) do
+        build_zip({
+          'PMC-11111.mp4' => mp4_data,
+          'PMC-22222.mp3' => mp3_data
+        })
+      end
+
+      it 'creates media with the correct media_type and content_type' do
+        expect {
+          described_class.new(zip_file.path, user).call
+        }.to change(Medium, :count).by(2)
+
+        video = Medium.find_by(sourcedb: 'PMC', sourceid: '11111')
+        expect(video).to have_attributes(media_type: 'video', content_type: 'video/mp4')
+
+        audio = Medium.find_by(sourcedb: 'PMC', sourceid: '22222')
+        expect(audio).to have_attributes(media_type: 'audio', content_type: 'audio/mpeg')
       end
     end
 

--- a/spec/services/medium_upload_entry_parser_spec.rb
+++ b/spec/services/medium_upload_entry_parser_spec.rb
@@ -31,6 +31,32 @@ RSpec.describe MediumUploadEntryParser do
       end
     end
 
+    context 'with a video filename' do
+      it 'returns a MediumUploadEntry with video attributes' do
+        entry = build_zip_entry('PMC-12345.mp4')
+
+        upload_entry = described_class.call(entry)
+
+        expect(upload_entry).to have_attributes(
+          media_type: :video,
+          content_type: 'video/mp4'
+        )
+      end
+    end
+
+    context 'with an audio filename' do
+      it 'returns a MediumUploadEntry with audio attributes' do
+        entry = build_zip_entry('PMC-12345.mp3')
+
+        upload_entry = described_class.call(entry)
+
+        expect(upload_entry).to have_attributes(
+          media_type: :audio,
+          content_type: 'audio/mpeg'
+        )
+      end
+    end
+
     context 'without an extension' do
       it 'raises a ValidationError' do
         entry = build_zip_entry('PMC-12345')


### PR DESCRIPTION
## 概要

mediaのバルクアップロードで音声と動画を登録できるようにしました。

## 動作確認

- 追加分を含むすべてのspecがパスすることを確認
- 以下のzipファイルをバルクアップロードのフォームに追加
[video_and_audio.zip](https://github.com/user-attachments/files/30248711/video_and_audio.zip)
中身は以下
<img width="314" height="180" alt="スクリーンショット 2026-07-22 10 33 12" src="https://github.com/user-attachments/assets/2aeaf43f-6850-41c5-8513-3eccf3b4eb15" />

- `test:audio` と `test:video` という`sourcedb:sourceid`のmediaが追加されたことを確認
- job詳細のmessageにerror.mp3が登録できなかった旨のメッセージが追加されていることを確認