### PR TITLE
Audio silence detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Please use it with
 * [redis](https://redis.io/)
 * [Ollama](https://ollama.com/) (for media caption generation)
 * [whisper.cpp](https://github.com/ggml-org/whisper.cpp) (for audio transcription)
+* [ffmpeg](https://ffmpeg.org/) (for detecting silent audio before transcription)
 
 ### Ollama setup (for media caption generation)
 
@@ -50,6 +51,13 @@ $ curl -L -o ~/models/ggml-base.en.bin https://huggingface.co/ggerganov/whisper.
 Note: the Homebrew build has no `whisper-server` binary, so transcription runs via `whisper-cli` directly instead of an HTTP server:
 ```
 $ whisper-cli -m ~/models/ggml-base.en.bin -f path/to/audio.wav
+```
+
+### ffmpeg setup (for detecting silent audio before transcription)
+
+Install ffmpeg:
+```
+$ brew install ffmpeg
 ```
 
 If your system does not already have an installation of ruby, you need to install it. Using [rvm](https://rvm.io/) is generally a recommended way to install ruby in your system.

--- a/app/services/audio_silence_detector.rb
+++ b/app/services/audio_silence_detector.rb
@@ -1,0 +1,16 @@
+class AudioSilenceDetector
+  THRESHOLD_DB = -50.0
+
+  def initialize(audio_path)
+    @audio_path = audio_path
+  end
+
+  def silent?
+    _stdout, stderr, _status = Open3.capture3('ffmpeg', '-i', @audio_path, '-af', 'volumedetect', '-f', 'null', '-')
+
+    match = stderr.match(/max_volume:\s*(-?\d+(?:\.\d+)?)\s*dB/)
+    return false unless match
+
+    match[1].to_f < THRESHOLD_DB
+  end
+end

--- a/app/services/audio_silence_detector.rb
+++ b/app/services/audio_silence_detector.rb
@@ -6,7 +6,8 @@ class AudioSilenceDetector
   end
 
   def silent?
-    _stdout, stderr, _status = Open3.capture3('ffmpeg', '-i', @audio_path, '-af', 'volumedetect', '-f', 'null', '-')
+    _stdout, stderr, status = Open3.capture3('ffmpeg', '-i', @audio_path, '-af', 'volumedetect', '-f', 'null', '-')
+    return false unless status.success?
 
     match = stderr.match(/max_volume:\s*(-?\d+(?:\.\d+)?)\s*dB/)
     return false unless match

--- a/app/services/audio_silence_detector.rb
+++ b/app/services/audio_silence_detector.rb
@@ -1,4 +1,6 @@
 class AudioSilenceDetector
+  class DetectionError < StandardError; end
+
   THRESHOLD_DB = -50.0
 
   def initialize(audio_path)
@@ -7,12 +9,14 @@ class AudioSilenceDetector
 
   def silent?
     _stdout, stderr, status = Open3.capture3('ffmpeg', '-i', @audio_path, '-af', 'volumedetect', '-f', 'null', '-')
-    return false unless status.success?
+    unless status.success?
+      raise DetectionError, "Failed to analyze audio with ffmpeg (status #{status.exitstatus}): #{stderr.strip}"
+    end
 
     # ffmpeg's volumedetect filter writes a line like this to stderr:
     #   [Parsed_volumedetect_0 @ 0x600001d50000] max_volume: -91.0 dB
     match = stderr.match(/max_volume:\s*(-?\d+(?:\.\d+)?)\s*dB/)
-    return false unless match
+    raise DetectionError, "Could not determine max_volume from ffmpeg output: #{stderr.strip}" unless match
 
     match[1].to_f < THRESHOLD_DB
   end

--- a/app/services/audio_silence_detector.rb
+++ b/app/services/audio_silence_detector.rb
@@ -9,6 +9,8 @@ class AudioSilenceDetector
     _stdout, stderr, status = Open3.capture3('ffmpeg', '-i', @audio_path, '-af', 'volumedetect', '-f', 'null', '-')
     return false unless status.success?
 
+    # ffmpeg's volumedetect filter writes a line like this to stderr:
+    #   [Parsed_volumedetect_0 @ 0x600001d50000] max_volume: -91.0 dB
     match = stderr.match(/max_volume:\s*(-?\d+(?:\.\d+)?)\s*dB/)
     return false unless match
 

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -4,6 +4,8 @@ class AudioTranscriptionService
   end
 
   def call
+    raise ArgumentError, "Audio file appears to be silent." if AudioSilenceDetector.new(@audio_path).silent?
+
     cli_path   = ENV.fetch('WHISPER_CLI_PATH', 'whisper-cli')
     model_path = File.expand_path(ENV.fetch('WHISPER_MODEL_PATH'))
 

--- a/spec/services/audio_silence_detector_spec.rb
+++ b/spec/services/audio_silence_detector_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AudioSilenceDetector do
+  let(:audio_path) { Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3').to_s }
+
+  describe '#silent?' do
+    def stub_ffmpeg_stderr(stderr)
+      allow(Open3).to receive(:capture3)
+        .with('ffmpeg', '-i', audio_path, '-af', 'volumedetect', '-f', 'null', '-')
+        .and_return(['', stderr, instance_double(Process::Status)])
+    end
+
+    it 'returns true when max_volume is below the threshold' do
+      stub_ffmpeg_stderr('[Parsed_volumedetect_0] max_volume: -91.0 dB')
+      expect(described_class.new(audio_path).silent?).to be true
+    end
+
+    it 'returns false when max_volume is above the threshold' do
+      stub_ffmpeg_stderr('[Parsed_volumedetect_0] max_volume: -2.1 dB')
+      expect(described_class.new(audio_path).silent?).to be false
+    end
+
+    it 'returns false when max_volume cannot be parsed from ffmpeg output' do
+      stub_ffmpeg_stderr('some unrelated ffmpeg error output')
+      expect(described_class.new(audio_path).silent?).to be false
+    end
+  end
+end

--- a/spec/services/audio_silence_detector_spec.rb
+++ b/spec/services/audio_silence_detector_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe AudioSilenceDetector do
   let(:audio_path) { Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3').to_s }
 
   describe '#silent?' do
-    def stub_ffmpeg_stderr(stderr)
+    def stub_ffmpeg_stderr(stderr, success: true)
       allow(Open3).to receive(:capture3)
         .with('ffmpeg', '-i', audio_path, '-af', 'volumedetect', '-f', 'null', '-')
-        .and_return(['', stderr, instance_double(Process::Status)])
+        .and_return(['', stderr, instance_double(Process::Status, success?: success)])
     end
 
     it 'returns true when max_volume is below the threshold' do
@@ -24,6 +24,11 @@ RSpec.describe AudioSilenceDetector do
 
     it 'returns false when max_volume cannot be parsed from ffmpeg output' do
       stub_ffmpeg_stderr('some unrelated ffmpeg error output')
+      expect(described_class.new(audio_path).silent?).to be false
+    end
+
+    it 'returns false when ffmpeg fails, even if stderr contains a volume-like reading' do
+      stub_ffmpeg_stderr('[Parsed_volumedetect_0] max_volume: -91.0 dB', success: false)
       expect(described_class.new(audio_path).silent?).to be false
     end
   end

--- a/spec/services/audio_silence_detector_spec.rb
+++ b/spec/services/audio_silence_detector_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe AudioSilenceDetector do
 
   describe '#silent?' do
     def stub_ffmpeg_stderr(stderr, success: true)
+      status = instance_double(Process::Status, success?: success, exitstatus: success ? 0 : 1)
       allow(Open3).to receive(:capture3)
         .with('ffmpeg', '-i', audio_path, '-af', 'volumedetect', '-f', 'null', '-')
-        .and_return(['', stderr, instance_double(Process::Status, success?: success)])
+        .and_return(['', stderr, status])
     end
 
     it 'returns true when max_volume is below the threshold' do
@@ -22,14 +23,20 @@ RSpec.describe AudioSilenceDetector do
       expect(described_class.new(audio_path).silent?).to be false
     end
 
-    it 'returns false when max_volume cannot be parsed from ffmpeg output' do
+    it 'raises DetectionError when max_volume cannot be parsed from ffmpeg output' do
       stub_ffmpeg_stderr('some unrelated ffmpeg error output')
-      expect(described_class.new(audio_path).silent?).to be false
+
+      expect {
+        described_class.new(audio_path).silent?
+      }.to raise_error(AudioSilenceDetector::DetectionError, /Could not determine max_volume/)
     end
 
-    it 'returns false when ffmpeg fails, even if stderr contains a volume-like reading' do
+    it 'raises DetectionError when ffmpeg fails, even if stderr contains a volume-like reading' do
       stub_ffmpeg_stderr('[Parsed_volumedetect_0] max_volume: -91.0 dB', success: false)
-      expect(described_class.new(audio_path).silent?).to be false
+
+      expect {
+        described_class.new(audio_path).silent?
+      }.to raise_error(AudioSilenceDetector::DetectionError, /Failed to analyze audio with ffmpeg/)
     end
   end
 end

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AudioTranscriptionService do
       end
 
       it 'raises without invoking whisper-cli' do
-        expect(Open3).not_to receive(:capture3)
+        expect(Open3).not_to receive(:capture3).with('whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
         expect {
           described_class.new(audio_path).call
         }.to raise_error(ArgumentError, /silent/)

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -18,6 +18,23 @@ RSpec.describe AudioTranscriptionService do
   end
 
   describe '#call' do
+    before do
+      allow(AudioSilenceDetector).to receive(:new).with(audio_path).and_return(instance_double(AudioSilenceDetector, silent?: false))
+    end
+
+    context 'when the audio is silent' do
+      before do
+        allow(AudioSilenceDetector).to receive(:new).with(audio_path).and_return(instance_double(AudioSilenceDetector, silent?: true))
+      end
+
+      it 'raises without invoking whisper-cli' do
+        expect(Open3).not_to receive(:capture3)
+        expect {
+          described_class.new(audio_path).call
+        }.to raise_error(ArgumentError, /silent/)
+      end
+    end
+
     context 'when whisper-cli succeeds' do
       before do
         success_status = instance_double(Process::Status, success?: true)


### PR DESCRIPTION
## 概要

無音トラックの場合はAugumentErrorをraiseして、whisperに対してリクエストを送らないようにしました。
判定には`ffmpeg`の`volumedetect`フィルタを使い、`max_volume`が閾値（-50dB）を下回っていれば無音とみなして文字起こしをスキップします。

**なぜRubyだけで完結させないのか**: アップロードされる音声はmp3・wav・oggのいずれか。wavは単純なヘッダ+生のPCMデータなのでRubyだけでパースするのは現実的ですが、mp3・oggは非可逆圧縮フォーマットで、実用的な純Rubyデコーダは存在しません。ffmpegであればこの3フォーマットすべてを一貫してデコードできるため、コーデックを自前実装したり、フォーマットごとに処理を分けたりするより現実的な選択です。

## 動作確認

追加分を含むすべてのspecがパスすることを確認

無音トラックを用意

[test_silent_audio.wav](https://github.com/user-attachments/files/30336959/test_silent_audio.wav)
mediaに登録後、コンソールでAudioTranscriptionServiceを呼ぶ
AugumentErrorで処理が中断されることを確認
<img width="1112" height="267" alt="スクリーンショット 2026-07-24 16 25 40" src="https://github.com/user-attachments/assets/005afab2-897b-4c2c-a6d4-2163abd47cf4" />

