### PR TITLE
Doc generation from audio

### DIFF
--- a/app/services/doc_generation_from_media.rb
+++ b/app/services/doc_generation_from_media.rb
@@ -9,15 +9,15 @@ class DocGenerationFromMedia
   def call
     validate_medium!
 
-    caption = @medium.file.open do |file|
-      ImageCaptionService.new(file.path).call
+    body = @medium.file.open do |file|
+      generate_text(file.path)
     end
 
     hdoc = Doc.hdoc_normalize!(
       {
         **@attributes,
         username: @user.username,
-        body: caption,
+        body: body,
         medium_id: @medium.id
       },
       @user,
@@ -31,8 +31,16 @@ class DocGenerationFromMedia
 
   private
 
+  def generate_text(file_path)
+    if @medium.image?
+      ImageCaptionService.new(file_path).call
+    else
+      AudioTranscriptionService.new(file_path).call
+    end
+  end
+
   def validate_medium!
-    raise ArgumentError, "Text generation is supported only for image media." unless @medium.image?
+    raise ArgumentError, "Text generation is supported only for image or audio media." unless @medium.image? || @medium.audio?
     raise ArgumentError, "Specified media has no attached file." unless @medium.file.attached?
   end
 end

--- a/app/services/doc_generation_from_media.rb
+++ b/app/services/doc_generation_from_media.rb
@@ -17,7 +17,7 @@ class DocGenerationFromMedia
       {
         **@attributes,
         username: @user.username,
-        body: body,
+        body:,
         medium_id: @medium.id
       },
       @user,

--- a/spec/requests/doc_generations_spec.rb
+++ b/spec/requests/doc_generations_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'DocGenerationsController', type: :request do
         expect(response).to redirect_to(new_project_doc_generation_path(project.name))
       end
 
-      it 'records an error on the job when the medium is not an image' do
+      it 'records an error on the job when the medium is neither image nor audio' do
         video_medium = create(:medium, media_type: :video, content_type: 'video/mp4')
 
         expect {
@@ -149,7 +149,7 @@ RSpec.describe 'DocGenerationsController', type: :request do
         }.not_to change(Doc, :count)
 
         expect(response).to redirect_to(project_docs_path(project.name))
-        expect(project.jobs.last.messages.last.body).to match(/image media/)
+        expect(project.jobs.last.messages.last.body).to match(/image or audio media/)
       end
 
       it 'records an error on the job when the medium has no attached file' do

--- a/spec/services/doc_generation_from_media_spec.rb
+++ b/spec/services/doc_generation_from_media_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe DocGenerationFromMedia do
     )
     medium
   end
+  let(:audio_medium) do
+    medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+    medium.file.attach(
+      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3')),
+      filename: 'test_audio.mp3',
+      content_type: 'audio/mpeg'
+    )
+    medium
+  end
 
   describe '#call' do
     context 'with a valid image medium' do
@@ -38,7 +47,29 @@ RSpec.describe DocGenerationFromMedia do
       end
     end
 
-    context 'when the medium is not an image' do
+    context 'with a valid audio medium' do
+      before do
+        allow(AudioTranscriptionService).to receive(:new).and_return(instance_double(AudioTranscriptionService, call: 'A generated transcript.'))
+      end
+
+      it 'creates a doc with the generated transcript, linked to the medium and the project' do
+        doc = described_class.new(
+          project: project,
+          medium: audio_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '002' }
+        ).call
+
+        expect(doc).to be_persisted
+        expect(doc.body).to eq('A generated transcript.')
+        expect(doc.sourcedb).to eq("Example@#{user.username}")
+        expect(doc.sourceid).to eq('002')
+        expect(doc.medium).to eq(audio_medium)
+        expect(project.docs).to include(doc)
+      end
+    end
+
+    context 'when the medium is neither image nor audio' do
       let(:video_medium) { create(:medium, media_type: :video, content_type: 'video/mp4') }
 
       it 'raises without creating a doc' do
@@ -49,7 +80,7 @@ RSpec.describe DocGenerationFromMedia do
             user: user,
             attributes: { source: nil, sourcedb: nil, sourceid: nil }
           ).call
-        }.to raise_error(ArgumentError, /image media/).and change(Doc, :count).by(0)
+        }.to raise_error(ArgumentError, /image or audio media/).and change(Doc, :count).by(0)
       end
     end
 


### PR DESCRIPTION
## 概要

文字起こしの処理を非同期で行えるようにしました。

## 動作確認

- 以下の音声をmedia登録画面で追加

  - [590331main_ringtone_smallStep.mp3](https://github.com/user-attachments/files/30397086/590331main_ringtone_smallStep.mp3)

- Generate a new document from mediaページで以上の音声を指定して登録
- `The document generation from media is submitted. The task, 'Generate doc text from media', is generating the text. You can check the result in your project page.`というメッセージが表示されることを確認
- 文字起こし結果がtextに登録されたdocが作成されることを確認

<img width="1033" height="893" alt="スクリーンショット 2026-07-27 11 18 10" src="https://github.com/user-attachments/assets/8197a68d-b636-4d39-a472-3703ff49ada6" />
