### PR TITLE
Add MediaTranscript resource

### DIFF
--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -69,6 +69,7 @@ class Doc < ActiveRecord::Base
 		:after_add => [:increment_docs_projects_counter, :queue_es_project_add],
 		:after_remove => [:decrement_docs_projects_counter, :queue_es_project_remove]
 	belongs_to :medium, optional: true
+	has_one :media_transcript, dependent: :destroy
 
 	validate :media_reference_immutable, on: :update
 

--- a/app/models/media_transcript.rb
+++ b/app/models/media_transcript.rb
@@ -3,9 +3,18 @@ class MediaTranscript < ApplicationRecord
 
   delegate :medium, to: :doc, allow_nil: true
 
+  # `segments` is an array of timed transcript segments. Each element is a hash with string keys:
+  #   'text'     - String, the transcribed text for the segment (may be blank).
+  #   'start_ms' - Integer >= 0, offset in milliseconds from the start of the media.
+  #   'end_ms'   - Integer >= 0, offset in milliseconds from the start of the media (>= start_ms).
+  # The interval is [start_ms, end_ms) (start inclusive, end exclusive), so consecutive segments
+  # are expected to touch (one segment's end_ms equals the next one's start_ms) rather than
+  # overlap. Segments are ordered chronologically: start_ms is non-decreasing across the array.
+  # An empty array means no speech was detected in the media.
   validates :doc_id, uniqueness: true
   validate :doc_has_medium
   validate :medium_not_image
+  validate :segments_are_valid
 
   private
 
@@ -15,5 +24,31 @@ class MediaTranscript < ApplicationRecord
 
   def medium_not_image
     errors.add(:medium, 'must not be an image') if medium&.image?
+  end
+
+  def segments_are_valid
+    return errors.add(:segments, 'must be an array') unless segments.is_a?(Array)
+
+    previous_start_ms = nil
+
+    segments.each_with_index do |segment, index|
+      unless valid_segment?(segment)
+        errors.add(:segments, "at index #{index} must be a hash with a 'text' string and non-negative integer " \
+                               "'start_ms'/'end_ms' where start_ms <= end_ms")
+        next
+      end
+
+      errors.add(:segments, "at index #{index} is out of order: start_ms must be non-decreasing") if
+        previous_start_ms && segment['start_ms'] < previous_start_ms
+
+      previous_start_ms = segment['start_ms']
+    end
+  end
+
+  def valid_segment?(segment)
+    segment.is_a?(Hash) &&
+      segment['text'].is_a?(String) &&
+      segment['start_ms'].is_a?(Integer) && segment['start_ms'] >= 0 &&
+      segment['end_ms'].is_a?(Integer) && segment['end_ms'] >= segment['start_ms']
   end
 end

--- a/app/models/media_transcript.rb
+++ b/app/models/media_transcript.rb
@@ -1,0 +1,6 @@
+class MediaTranscript < ApplicationRecord
+  belongs_to :medium
+  belongs_to :doc
+
+  validates :doc_id, uniqueness: true
+end

--- a/app/models/media_transcript.rb
+++ b/app/models/media_transcript.rb
@@ -4,10 +4,17 @@ class MediaTranscript < ApplicationRecord
 
   validates :doc_id, uniqueness: true
   validate :medium_not_image
+  validate :medium_matches_doc_medium
 
   private
 
   def medium_not_image
     errors.add(:medium, 'must not be an image') if medium&.image?
+  end
+
+  def medium_matches_doc_medium
+    return unless medium && doc
+
+    errors.add(:doc, 'must reference the same medium as this transcript') if doc.medium_id != medium_id
   end
 end

--- a/app/models/media_transcript.rb
+++ b/app/models/media_transcript.rb
@@ -3,4 +3,11 @@ class MediaTranscript < ApplicationRecord
   belongs_to :doc
 
   validates :doc_id, uniqueness: true
+  validate :medium_not_image
+
+  private
+
+  def medium_not_image
+    errors.add(:medium, 'must not be an image') if medium&.image?
+  end
 end

--- a/app/models/media_transcript.rb
+++ b/app/models/media_transcript.rb
@@ -1,20 +1,19 @@
 class MediaTranscript < ApplicationRecord
-  belongs_to :medium
   belongs_to :doc
 
+  delegate :medium, to: :doc, allow_nil: true
+
   validates :doc_id, uniqueness: true
+  validate :doc_has_medium
   validate :medium_not_image
-  validate :medium_matches_doc_medium
 
   private
 
-  def medium_not_image
-    errors.add(:medium, 'must not be an image') if medium&.image?
+  def doc_has_medium
+    errors.add(:doc, 'must have an associated medium') if doc && medium.nil?
   end
 
-  def medium_matches_doc_medium
-    return unless medium && doc
-
-    errors.add(:doc, 'must reference the same medium as this transcript') if doc.medium_id != medium_id
+  def medium_not_image
+    errors.add(:medium, 'must not be an image') if medium&.image?
   end
 end

--- a/app/models/media_transcript.rb
+++ b/app/models/media_transcript.rb
@@ -7,9 +7,10 @@ class MediaTranscript < ApplicationRecord
   #   'text'     - String, the transcribed text for the segment (may be blank).
   #   'start_ms' - Integer >= 0, offset in milliseconds from the start of the media.
   #   'end_ms'   - Integer >= 0, offset in milliseconds from the start of the media (>= start_ms).
-  # The interval is [start_ms, end_ms) (start inclusive, end exclusive), so consecutive segments
-  # are expected to touch (one segment's end_ms equals the next one's start_ms) rather than
-  # overlap. Segments are ordered chronologically: start_ms is non-decreasing across the array.
+  # The interval is [start_ms, end_ms) (start inclusive, end exclusive). Segments are ordered
+  # chronologically and must not overlap: each segment's start_ms must be >= the previous
+  # segment's end_ms. Gaps are allowed (e.g. silence between segments), so consecutive segments
+  # are not required to touch exactly.
   # An empty array means no speech was detected in the media.
   validates :doc_id, uniqueness: true
   validate :doc_has_medium
@@ -29,7 +30,7 @@ class MediaTranscript < ApplicationRecord
   def segments_are_valid
     return errors.add(:segments, 'must be an array') unless segments.is_a?(Array)
 
-    previous_start_ms = nil
+    previous_end_ms = nil
 
     segments.each_with_index do |segment, index|
       unless valid_segment?(segment)
@@ -38,10 +39,10 @@ class MediaTranscript < ApplicationRecord
         next
       end
 
-      errors.add(:segments, "at index #{index} is out of order: start_ms must be non-decreasing") if
-        previous_start_ms && segment['start_ms'] < previous_start_ms
+      errors.add(:segments, "at index #{index} overlaps the previous segment: start_ms must be >= the previous end_ms") if
+        previous_end_ms && segment['start_ms'] < previous_end_ms
 
-      previous_start_ms = segment['start_ms']
+      previous_end_ms = segment['end_ms']
     end
   end
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -3,6 +3,7 @@ class Medium < ApplicationRecord
 
   belongs_to :user
   has_many :docs, dependent: :destroy
+  has_many :media_transcripts, dependent: :destroy
 
   enum :media_type, { image: 0, video: 1, audio: 2 }
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -3,7 +3,6 @@ class Medium < ApplicationRecord
 
   belongs_to :user
   has_many :docs, dependent: :destroy
-  has_many :media_transcripts, dependent: :destroy
 
   enum :media_type, { image: 0, video: 1, audio: 2 }
 

--- a/db/migrate/20260803025230_create_media_transcripts.rb
+++ b/db/migrate/20260803025230_create_media_transcripts.rb
@@ -1,7 +1,6 @@
 class CreateMediaTranscripts < ActiveRecord::Migration[8.1]
   def change
     create_table :media_transcripts do |t|
-      t.references :medium, null: false, foreign_key: { on_delete: :cascade }
       t.references :doc, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
       t.json :segments, null: false, default: []
 

--- a/db/migrate/20260803025230_create_media_transcripts.rb
+++ b/db/migrate/20260803025230_create_media_transcripts.rb
@@ -1,0 +1,11 @@
+class CreateMediaTranscripts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :media_transcripts do |t|
+      t.references :medium, null: false, foreign_key: true
+      t.references :doc, null: false, foreign_key: true, index: { unique: true }
+      t.json :segments, null: false, default: []
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260803025230_create_media_transcripts.rb
+++ b/db/migrate/20260803025230_create_media_transcripts.rb
@@ -1,8 +1,8 @@
 class CreateMediaTranscripts < ActiveRecord::Migration[8.1]
   def change
     create_table :media_transcripts do |t|
-      t.references :medium, null: false, foreign_key: true
-      t.references :doc, null: false, foreign_key: true, index: { unique: true }
+      t.references :medium, null: false, foreign_key: { on_delete: :cascade }
+      t.references :doc, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
       t.json :segments, null: false, default: []
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_010154) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_025230) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -291,6 +291,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_010154) do
     t.index ["user_id"], name: "index_media_on_user_id"
   end
 
+  create_table "media_transcripts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "doc_id", null: false
+    t.bigint "medium_id", null: false
+    t.json "segments", default: [], null: false
+    t.datetime "updated_at", null: false
+    t.index ["doc_id"], name: "index_media_transcripts_on_doc_id", unique: true
+    t.index ["medium_id"], name: "index_media_transcripts_on_medium_id"
+  end
+
   create_table "messages", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -518,6 +528,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_010154) do
   add_foreign_key "batch_job_trackings", "jobs", column: "parent_job_id", on_delete: :cascade
   add_foreign_key "docs", "media"
   add_foreign_key "media", "users"
+  add_foreign_key "media_transcripts", "docs"
+  add_foreign_key "media_transcripts", "media"
   add_foreign_key "paragraph_attrivutes", "attrivutes"
   add_foreign_key "paragraph_attrivutes", "divisions"
   add_foreign_key "paragraph_denotations", "denotations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -528,8 +528,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_025230) do
   add_foreign_key "batch_job_trackings", "jobs", column: "parent_job_id", on_delete: :cascade
   add_foreign_key "docs", "media"
   add_foreign_key "media", "users"
-  add_foreign_key "media_transcripts", "docs"
-  add_foreign_key "media_transcripts", "media"
+  add_foreign_key "media_transcripts", "docs", on_delete: :cascade
+  add_foreign_key "media_transcripts", "media", on_delete: :cascade
   add_foreign_key "paragraph_attrivutes", "attrivutes"
   add_foreign_key "paragraph_attrivutes", "divisions"
   add_foreign_key "paragraph_denotations", "denotations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -294,11 +294,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_025230) do
   create_table "media_transcripts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "doc_id", null: false
-    t.bigint "medium_id", null: false
     t.json "segments", default: [], null: false
     t.datetime "updated_at", null: false
     t.index ["doc_id"], name: "index_media_transcripts_on_doc_id", unique: true
-    t.index ["medium_id"], name: "index_media_transcripts_on_medium_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -529,7 +527,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_025230) do
   add_foreign_key "docs", "media"
   add_foreign_key "media", "users"
   add_foreign_key "media_transcripts", "docs", on_delete: :cascade
-  add_foreign_key "media_transcripts", "media", on_delete: :cascade
   add_foreign_key "paragraph_attrivutes", "attrivutes"
   add_foreign_key "paragraph_attrivutes", "divisions"
   add_foreign_key "paragraph_denotations", "denotations"

--- a/spec/factories/media_transcripts.rb
+++ b/spec/factories/media_transcripts.rb
@@ -2,8 +2,7 @@
 
 FactoryBot.define do
   factory :media_transcript do
-    association :medium, media_type: :audio, content_type: 'audio/mpeg'
-    doc { association(:doc, medium: medium) }
+    doc { association(:doc, medium: association(:medium, media_type: :audio, content_type: 'audio/mpeg')) }
     segments do
       [
         { 'text' => 'Hello', 'start_ms' => 0, 'end_ms' => 300 },

--- a/spec/factories/media_transcripts.rb
+++ b/spec/factories/media_transcripts.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :media_transcript do
     association :medium, media_type: :audio, content_type: 'audio/mpeg'
-    association :doc
+    doc { association(:doc, medium: medium) }
     segments do
       [
         { 'text' => 'Hello', 'start_ms' => 0, 'end_ms' => 300 },

--- a/spec/factories/media_transcripts.rb
+++ b/spec/factories/media_transcripts.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :media_transcript do
-    association :medium
+    association :medium, media_type: :audio, content_type: 'audio/mpeg'
     association :doc
     segments do
       [

--- a/spec/factories/media_transcripts.rb
+++ b/spec/factories/media_transcripts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :media_transcript do
+    association :medium
+    association :doc
+    segments do
+      [
+        { 'text' => 'Hello', 'start_ms' => 0, 'end_ms' => 300 },
+        { 'text' => 'world', 'start_ms' => 300, 'end_ms' => 600 }
+      ]
+    end
+  end
+end

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -22,11 +22,17 @@ RSpec.describe MediaTranscript, type: :model do
 
       expect(build(:media_transcript, doc: doc)).not_to be_valid
     end
+
+    it 'rejects a medium whose media_type is image' do
+      medium = create(:medium, media_type: :image, content_type: 'image/jpeg')
+
+      expect(build(:media_transcript, medium: medium)).not_to be_valid
+    end
   end
 
   describe 'associations' do
     it 'belongs to a medium' do
-      medium = create(:medium)
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
       media_transcript = create(:media_transcript, medium: medium)
 
       expect(media_transcript.medium).to eq(medium)
@@ -51,7 +57,7 @@ RSpec.describe MediaTranscript, type: :model do
     end
 
     it 'is destroyed when its medium is destroyed' do
-      medium = create(:medium)
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
       media_transcript = create(:media_transcript, medium: medium)
 
       medium.destroy
@@ -68,7 +74,7 @@ RSpec.describe MediaTranscript, type: :model do
     end
 
     it 'defaults to an empty array' do
-      medium = create(:medium)
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
       doc = create(:doc)
 
       media_transcript = MediaTranscript.new(medium: medium, doc: doc)

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MediaTranscript, type: :model do
+  describe 'validations' do
+    it 'is valid with valid attributes' do
+      expect(build(:media_transcript)).to be_valid
+    end
+
+    it 'requires a medium' do
+      expect(build(:media_transcript, medium: nil)).not_to be_valid
+    end
+
+    it 'requires a doc' do
+      expect(build(:media_transcript, doc: nil)).not_to be_valid
+    end
+
+    it 'requires doc_id to be unique' do
+      doc = create(:doc)
+      create(:media_transcript, doc: doc)
+
+      expect(build(:media_transcript, doc: doc)).not_to be_valid
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a medium' do
+      medium = create(:medium)
+      media_transcript = create(:media_transcript, medium: medium)
+
+      expect(media_transcript.medium).to eq(medium)
+    end
+
+    it 'belongs to a doc' do
+      doc = create(:doc)
+      media_transcript = create(:media_transcript, doc: doc)
+
+      expect(media_transcript.doc).to eq(doc)
+    end
+  end
+
+  describe 'dependent destroy' do
+    it 'is destroyed when its doc is destroyed' do
+      doc = create(:doc)
+      media_transcript = create(:media_transcript, doc: doc)
+
+      doc.destroy
+
+      expect(MediaTranscript.exists?(media_transcript.id)).to be false
+    end
+
+    it 'is destroyed when its medium is destroyed' do
+      medium = create(:medium)
+      media_transcript = create(:media_transcript, medium: medium)
+
+      medium.destroy
+
+      expect(MediaTranscript.exists?(media_transcript.id)).to be false
+    end
+  end
+
+  describe 'segments' do
+    it 'stores an array of timed text segments' do
+      media_transcript = create(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => 0, 'end_ms' => 100 }])
+
+      expect(media_transcript.reload.segments).to eq([{ 'text' => 'Hi', 'start_ms' => 0, 'end_ms' => 100 }])
+    end
+
+    it 'defaults to an empty array' do
+      medium = create(:medium)
+      doc = create(:doc)
+
+      media_transcript = MediaTranscript.new(medium: medium, doc: doc)
+
+      expect(media_transcript.segments).to eq([])
+    end
+  end
+end

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -89,5 +89,42 @@ RSpec.describe MediaTranscript, type: :model do
 
       expect(media_transcript.segments).to eq([])
     end
+
+    it 'is valid with an empty array' do
+      expect(build(:media_transcript, segments: [])).to be_valid
+    end
+
+    it 'is valid when a segment has equal start_ms and end_ms' do
+      expect(build(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => 100, 'end_ms' => 100 }])).to be_valid
+    end
+
+    it 'rejects segments that are not an array' do
+      expect(build(:media_transcript, segments: { 'text' => 'Hi', 'start_ms' => 0, 'end_ms' => 100 })).not_to be_valid
+    end
+
+    it 'rejects a segment missing required keys' do
+      expect(build(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => 0 }])).not_to be_valid
+    end
+
+    it 'rejects a segment whose text is not a string' do
+      expect(build(:media_transcript, segments: [{ 'text' => nil, 'start_ms' => 0, 'end_ms' => 100 }])).not_to be_valid
+    end
+
+    it 'rejects a segment with a negative start_ms' do
+      expect(build(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => -1, 'end_ms' => 100 }])).not_to be_valid
+    end
+
+    it 'rejects a segment whose end_ms is before its start_ms' do
+      expect(build(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => 100, 'end_ms' => 0 }])).not_to be_valid
+    end
+
+    it 'rejects segments that are out of chronological order' do
+      segments = [
+        { 'text' => 'world', 'start_ms' => 300, 'end_ms' => 600 },
+        { 'text' => 'Hello', 'start_ms' => 0, 'end_ms' => 300 }
+      ]
+
+      expect(build(:media_transcript, segments: segments)).not_to be_valid
+    end
   end
 end

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -114,6 +114,18 @@ RSpec.describe MediaTranscript, type: :model do
       expect(build(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => -1, 'end_ms' => 100 }])).not_to be_valid
     end
 
+    it 'rejects a segment whose start_ms is not an integer' do
+      expect(build(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => '0', 'end_ms' => 100 }])).not_to be_valid
+    end
+
+    it 'rejects a segment whose end_ms is not an integer' do
+      expect(build(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => 0, 'end_ms' => 100.0 }])).not_to be_valid
+    end
+
+    it 'rejects a segment that is not a hash' do
+      expect(build(:media_transcript, segments: ['not a hash'])).not_to be_valid
+    end
+
     it 'rejects a segment whose end_ms is before its start_ms' do
       expect(build(:media_transcript, segments: [{ 'text' => 'Hi', 'start_ms' => 100, 'end_ms' => 0 }])).not_to be_valid
     end

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -17,16 +17,32 @@ RSpec.describe MediaTranscript, type: :model do
     end
 
     it 'requires doc_id to be unique' do
-      doc = create(:doc)
-      create(:media_transcript, doc: doc)
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+      doc = create(:doc, medium: medium)
+      create(:media_transcript, medium: medium, doc: doc)
 
-      expect(build(:media_transcript, doc: doc)).not_to be_valid
+      expect(build(:media_transcript, medium: medium, doc: doc)).not_to be_valid
     end
 
     it 'rejects a medium whose media_type is image' do
       medium = create(:medium, media_type: :image, content_type: 'image/jpeg')
 
       expect(build(:media_transcript, medium: medium)).not_to be_valid
+    end
+
+    it 'rejects a doc whose medium differs from the transcript medium' do
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+      other_medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+      doc = create(:doc, medium: other_medium)
+
+      expect(build(:media_transcript, medium: medium, doc: doc)).not_to be_valid
+    end
+
+    it 'rejects a doc with no medium reference' do
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+      doc = create(:doc)
+
+      expect(build(:media_transcript, medium: medium, doc: doc)).not_to be_valid
     end
   end
 
@@ -39,8 +55,9 @@ RSpec.describe MediaTranscript, type: :model do
     end
 
     it 'belongs to a doc' do
-      doc = create(:doc)
-      media_transcript = create(:media_transcript, doc: doc)
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+      doc = create(:doc, medium: medium)
+      media_transcript = create(:media_transcript, medium: medium, doc: doc)
 
       expect(media_transcript.doc).to eq(doc)
     end
@@ -48,8 +65,9 @@ RSpec.describe MediaTranscript, type: :model do
 
   describe 'dependent destroy' do
     it 'is destroyed when its doc is destroyed' do
-      doc = create(:doc)
-      media_transcript = create(:media_transcript, doc: doc)
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+      doc = create(:doc, medium: medium)
+      media_transcript = create(:media_transcript, medium: medium, doc: doc)
 
       doc.destroy
 
@@ -75,7 +93,7 @@ RSpec.describe MediaTranscript, type: :model do
 
     it 'defaults to an empty array' do
       medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
-      doc = create(:doc)
+      doc = create(:doc, medium: medium)
 
       media_transcript = MediaTranscript.new(medium: medium, doc: doc)
 

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe MediaTranscript, type: :model do
       expect(build(:media_transcript)).to be_valid
     end
 
-    it 'requires a medium' do
-      expect(build(:media_transcript, medium: nil)).not_to be_valid
-    end
-
     it 'requires a doc' do
       expect(build(:media_transcript, doc: nil)).not_to be_valid
     end
@@ -19,37 +15,30 @@ RSpec.describe MediaTranscript, type: :model do
     it 'requires doc_id to be unique' do
       medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
       doc = create(:doc, medium: medium)
-      create(:media_transcript, medium: medium, doc: doc)
+      create(:media_transcript, doc: doc)
 
-      expect(build(:media_transcript, medium: medium, doc: doc)).not_to be_valid
+      expect(build(:media_transcript, doc: doc)).not_to be_valid
     end
 
-    it 'rejects a medium whose media_type is image' do
+    it 'rejects a doc whose medium is an image' do
       medium = create(:medium, media_type: :image, content_type: 'image/jpeg')
+      doc = create(:doc, medium: medium)
 
-      expect(build(:media_transcript, medium: medium)).not_to be_valid
-    end
-
-    it 'rejects a doc whose medium differs from the transcript medium' do
-      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
-      other_medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
-      doc = create(:doc, medium: other_medium)
-
-      expect(build(:media_transcript, medium: medium, doc: doc)).not_to be_valid
+      expect(build(:media_transcript, doc: doc)).not_to be_valid
     end
 
     it 'rejects a doc with no medium reference' do
-      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
       doc = create(:doc)
 
-      expect(build(:media_transcript, medium: medium, doc: doc)).not_to be_valid
+      expect(build(:media_transcript, doc: doc)).not_to be_valid
     end
   end
 
   describe 'associations' do
-    it 'belongs to a medium' do
+    it 'derives its medium from the doc' do
       medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
-      media_transcript = create(:media_transcript, medium: medium)
+      doc = create(:doc, medium: medium)
+      media_transcript = create(:media_transcript, doc: doc)
 
       expect(media_transcript.medium).to eq(medium)
     end
@@ -57,7 +46,7 @@ RSpec.describe MediaTranscript, type: :model do
     it 'belongs to a doc' do
       medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
       doc = create(:doc, medium: medium)
-      media_transcript = create(:media_transcript, medium: medium, doc: doc)
+      media_transcript = create(:media_transcript, doc: doc)
 
       expect(media_transcript.doc).to eq(doc)
     end
@@ -67,7 +56,7 @@ RSpec.describe MediaTranscript, type: :model do
     it 'is destroyed when its doc is destroyed' do
       medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
       doc = create(:doc, medium: medium)
-      media_transcript = create(:media_transcript, medium: medium, doc: doc)
+      media_transcript = create(:media_transcript, doc: doc)
 
       doc.destroy
 
@@ -76,7 +65,8 @@ RSpec.describe MediaTranscript, type: :model do
 
     it 'is destroyed when its medium is destroyed' do
       medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
-      media_transcript = create(:media_transcript, medium: medium)
+      doc = create(:doc, medium: medium)
+      media_transcript = create(:media_transcript, doc: doc)
 
       medium.destroy
 
@@ -95,7 +85,7 @@ RSpec.describe MediaTranscript, type: :model do
       medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
       doc = create(:doc, medium: medium)
 
-      media_transcript = MediaTranscript.new(medium: medium, doc: doc)
+      media_transcript = MediaTranscript.new(doc: doc)
 
       expect(media_transcript.segments).to eq([])
     end

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -138,5 +138,23 @@ RSpec.describe MediaTranscript, type: :model do
 
       expect(build(:media_transcript, segments: segments)).not_to be_valid
     end
+
+    it 'rejects overlapping segments' do
+      segments = [
+        { 'text' => 'Hello', 'start_ms' => 0, 'end_ms' => 300 },
+        { 'text' => 'world', 'start_ms' => 100, 'end_ms' => 400 }
+      ]
+
+      expect(build(:media_transcript, segments: segments)).not_to be_valid
+    end
+
+    it 'allows a gap between segments' do
+      segments = [
+        { 'text' => 'Hello', 'start_ms' => 0, 'end_ms' => 300 },
+        { 'text' => 'world', 'start_ms' => 500, 'end_ms' => 800 }
+      ]
+
+      expect(build(:media_transcript, segments: segments)).to be_valid
+    end
   end
 end


### PR DESCRIPTION
## 概要

以下の要件に沿ってMediaTranscriptテーブルとモデルを作成しました。
```md
#### MediaTranscriptリソース

MediaTranscriptリソースを追加する。
MediaTranscriptは、動画・音声MediaとDoc本文の時間対応関係を保存するためのリソースである。
生成テキスト本文はDoc.bodyに保存し、MediaTranscriptには時間情報JSONを保存する。

MediaTranscriptリソースの属性は以下の通り

- Mediaリソースへの外部キー
- Docリソースへの外部キー
- 文字起こし情報（JSON）
  - 動画や音声の再生位置とテキストの対応関係を保存するための情報
  - JSON形式を想定

画像の場合は作成しない。
生成テキスト自体はDocリソースとして保存する。
```

想定しているデータ
[590331main_ringtone_smallStep.mp3](https://github.com/user-attachments/files/31204704/590331main_ringtone_smallStep.mp3)を例に

```ruby
{
  "medium_id": 61,
  "doc_id": 216,
  "segments": [
    { "text": "I'm going to step off the land now. That's one", "start_ms": 0,     "end_ms": 12980 },
    { "text": "small step for man. One giant leap for mankind.", "start_ms": 12980, "end_ms": 30000 }
  ],
  "created_at": "2026-08-19 02:31:44 UTC",
  "updated_at": "2026-08-19 02:31:44 UTC"
}
```
> **注**: 上記の`end_ms: 30000`は、whisper-cli単体で書き起こしを行った際に実際に観測された値をそのまま載せている。
> 音声の実長は12980msだが、whisper-cliは末尾セグメントの終端を実際の音声長ではなく処理ウィンドウ（30秒）の終端に丸める癖があり、この例はその挙動が再現したもの。
> 実際に文字起こし生成〜MediaTranscript保存までのパイプラインを実装する際は、`end_ms`を音声/動画の実長でクランプする処理が別途必要になる見込み（本PRのスコープ外）。


## 動作確認

追加分を含む全てのspecがパスすることを確認しました。
