### PR TITLE
Add MediaTranscriptionTask resource

### DIFF
--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -1,0 +1,12 @@
+class MediaTranscriptionTask < ApplicationRecord
+  belongs_to :medium
+  belongs_to :job, optional: true
+
+  enum :status, {
+    pending: 'pending',
+    processing: 'processing',
+    succeeded: 'succeeded',
+    no_speech: 'no_speech',
+    failed: 'failed'
+  }
+end

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -1,3 +1,24 @@
+# Tracks a single attempt to transcribe one Medium (audio/video only; images are captioned,
+# not transcribed, and have no task). `status` is the machine-readable outcome of that attempt
+# (pending/processing/succeeded/no_speech/failed), independent of whether the attempt produced
+# a persisted Doc/MediaTranscript. This is what lets "not yet processed" and "processing
+# failed" be told apart, since neither one leaves any other record behind. A Medium may have
+# more than one task over time (e.g. a retry after a failure); there is no uniqueness
+# constraint on medium_id.
+#
+# This is a dedicated resource rather than an extension of Job because Job is a generic,
+# cross-media background-job tracker: it belongs to an organization/Project (not a Medium),
+# derives its state from begun_at/ended_at timestamps, tracks progress via num_items/num_dones,
+# is user-deletable, and its #destroy bypasses ActiveRecord callbacks via a raw `self.delete`
+# (so a `has_many ... dependent: :destroy` on Job would not even fire). Teaching Job to answer
+# "what's the transcription status of this Medium" would require generalizing it with a
+# polymorphic subject (subject_type/subject_id), spreading transcription-specific concerns
+# into every other kind of Job.
+#
+# It is kept separate from MediaTranscript because that model represents the successful
+# *output* of a transcription (the segments) and should only exist when there is real content
+# to show. MediaTranscriptionTask represents the *attempt* itself, including states (pending,
+# processing, failed) where no output exists at all.
 class MediaTranscriptionTask < ApplicationRecord
   belongs_to :medium
   belongs_to :job, optional: true

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -24,6 +24,7 @@ class MediaTranscriptionTask < ApplicationRecord
   belongs_to :job, optional: true
 
   validates :status, presence: true
+  validate :medium_must_be_audio_or_video
 
   enum :status, {
     pending: 'pending',
@@ -32,4 +33,12 @@ class MediaTranscriptionTask < ApplicationRecord
     no_speech: 'no_speech',
     failed: 'failed'
   }
+
+  private
+
+  def medium_must_be_audio_or_video
+    return unless medium
+
+    errors.add(:medium, 'must be audio or video') unless medium.audio? || medium.video?
+  end
 end

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -2,6 +2,8 @@ class MediaTranscriptionTask < ApplicationRecord
   belongs_to :medium
   belongs_to :job, optional: true
 
+  validates :status, presence: true
+
   enum :status, {
     pending: 'pending',
     processing: 'processing',

--- a/db/migrate/20260825084502_create_media_transcription_tasks.rb
+++ b/db/migrate/20260825084502_create_media_transcription_tasks.rb
@@ -1,0 +1,11 @@
+class CreateMediaTranscriptionTasks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :media_transcription_tasks do |t|
+      t.references :medium, null: false, foreign_key: { on_delete: :cascade }
+      t.references :job, null: true, foreign_key: { on_delete: :cascade }
+      t.string :status, null: false, default: 'pending'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_025230) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_084502) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -291,6 +291,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_025230) do
     t.index ["user_id"], name: "index_media_on_user_id"
   end
 
+  create_table "media_transcription_tasks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id"
+    t.bigint "medium_id", null: false
+    t.string "status", default: "pending", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_id"], name: "index_media_transcription_tasks_on_job_id"
+    t.index ["medium_id"], name: "index_media_transcription_tasks_on_medium_id"
+  end
+
   create_table "media_transcripts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "doc_id", null: false
@@ -526,6 +536,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_025230) do
   add_foreign_key "batch_job_trackings", "jobs", column: "parent_job_id", on_delete: :cascade
   add_foreign_key "docs", "media"
   add_foreign_key "media", "users"
+  add_foreign_key "media_transcription_tasks", "jobs", on_delete: :cascade
+  add_foreign_key "media_transcription_tasks", "media", on_delete: :cascade
   add_foreign_key "media_transcripts", "docs", on_delete: :cascade
   add_foreign_key "paragraph_attrivutes", "attrivutes"
   add_foreign_key "paragraph_attrivutes", "divisions"

--- a/spec/factories/media_transcription_tasks.rb
+++ b/spec/factories/media_transcription_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :media_transcription_task do
+    association :medium, media_type: :audio, content_type: 'audio/mpeg'
+    status { 'pending' }
+  end
+end

--- a/spec/models/media_transcription_task_spec.rb
+++ b/spec/models/media_transcription_task_spec.rb
@@ -27,6 +27,24 @@ RSpec.describe MediaTranscriptionTask, type: :model do
     it 'rejects a nil status' do
       expect(build(:media_transcription_task, status: nil)).not_to be_valid
     end
+
+    it 'rejects a medium whose media_type is image' do
+      medium = create(:medium, media_type: :image, content_type: 'image/jpeg')
+
+      expect(build(:media_transcription_task, medium: medium)).not_to be_valid
+    end
+
+    it 'accepts an audio medium' do
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+
+      expect(build(:media_transcription_task, medium: medium)).to be_valid
+    end
+
+    it 'accepts a video medium' do
+      medium = create(:medium, media_type: :video, content_type: 'video/mp4')
+
+      expect(build(:media_transcription_task, medium: medium)).to be_valid
+    end
   end
 
   describe 'associations' do

--- a/spec/models/media_transcription_task_spec.rb
+++ b/spec/models/media_transcription_task_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe MediaTranscriptionTask, type: :model do
     it 'rejects a status outside the defined enum' do
       expect { build(:media_transcription_task, status: 'bogus') }.to raise_error(ArgumentError)
     end
+
+    it 'rejects a nil status' do
+      expect(build(:media_transcription_task, status: nil)).not_to be_valid
+    end
   end
 
   describe 'associations' do

--- a/spec/models/media_transcription_task_spec.rb
+++ b/spec/models/media_transcription_task_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MediaTranscriptionTask, type: :model do
+  describe 'validations' do
+    it 'is valid with valid attributes' do
+      expect(build(:media_transcription_task)).to be_valid
+    end
+
+    it 'requires a medium' do
+      expect(build(:media_transcription_task, medium: nil)).not_to be_valid
+    end
+
+    it 'does not require a job' do
+      expect(build(:media_transcription_task, job: nil)).to be_valid
+    end
+
+    it 'defaults to pending status' do
+      expect(MediaTranscriptionTask.new.status).to eq('pending')
+    end
+
+    it 'rejects a status outside the defined enum' do
+      expect { build(:media_transcription_task, status: 'bogus') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a medium' do
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+      media_transcription_task = create(:media_transcription_task, medium: medium)
+
+      expect(media_transcription_task.medium).to eq(medium)
+    end
+
+    it 'belongs to a job' do
+      job = create(:job)
+      media_transcription_task = create(:media_transcription_task, job: job)
+
+      expect(media_transcription_task.job).to eq(job)
+    end
+
+    it 'allows multiple tasks for the same medium' do
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+      create(:media_transcription_task, medium: medium)
+
+      expect(build(:media_transcription_task, medium: medium)).to be_valid
+    end
+  end
+
+  describe 'status' do
+    %w[pending processing succeeded no_speech failed].each do |status|
+      it "supports the #{status} status" do
+        media_transcription_task = build(:media_transcription_task, status: status)
+
+        expect(media_transcription_task.status).to eq(status)
+        expect(media_transcription_task.public_send("#{status}?")).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

https://luxiar.slack.com/archives/C01S85B6SF9/p1787644651922179?thread_ts=1787642237.268049&cid=C01S85B6SF9

以上をもとにMediaTranscriptionTaskリソースを作成しました。

- 作成したカラム
  - `medium_id`: 必須、`on_delete: :cascade`
  - `job_id`  nullを許容、`on_delete: :cascade`
  - `status`: 必須、デフォルトはpending
```ruby
  enum :status, {
    pending: 'pending',
    processing: 'processing',
    succeeded: 'succeeded',
    no_speech: 'no_speech',
    failed: 'failed'
  }
```

- specを作成しました。

  - バリデーション
  - job, mediumの関連
  - statusの値が正しく判定できるか

## 動作確認

追加分を含めたすべてのspecがパスすることを確認しました。