### PR TITLE
Track transcription attempts via MediaTranscriptionTask in DocGenerationFromMediaJob

### DIFF
--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -5,9 +5,13 @@ class DocGenerationFromMediaJob < ApplicationJob
 
   def perform(project, medium, user, attributes)
     service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
-    task = MediaTranscriptionTask.create!(medium:, job: @job) if medium.transcribable?
 
-    body = medium.transcribable? ? task.process { service.generate_transcript } : service.generate_transcript
+    body = if medium.transcribable?
+      MediaTranscriptionTask.create!(medium:, job: @job).process { service.generate_transcript }
+    else
+      service.generate_transcript
+    end
+
     service.save_doc(body)
   end
 

--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -5,7 +5,7 @@ class DocGenerationFromMediaJob < ApplicationJob
 
   def perform(project, medium, user, attributes)
     service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
-    task = MediaTranscriptionTask.create!(medium:, job: @job) if transcribable?(medium)
+    task = MediaTranscriptionTask.create!(medium:, job: @job) if medium.transcribable?
 
     task&.processing!
     body = service.generate_transcript
@@ -19,11 +19,5 @@ class DocGenerationFromMediaJob < ApplicationJob
 
   def job_name
     'Generate doc text from media'
-  end
-
-  private
-
-  def transcribable?(medium)
-    medium.audio? || medium.video?
   end
 end

--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -7,14 +7,8 @@ class DocGenerationFromMediaJob < ApplicationJob
     service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
     task = MediaTranscriptionTask.create!(medium:, job: @job) if medium.transcribable?
 
-    task&.processing!
-    body = service.generate_transcript
-    task&.succeeded!
-
+    body = task ? task.process { service.generate_transcript } : service.generate_transcript
     service.save_doc(body)
-  rescue StandardError
-    task.failed! if task && !task.succeeded?
-    raise
   end
 
   def job_name

--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -7,7 +7,7 @@ class DocGenerationFromMediaJob < ApplicationJob
     service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
     task = MediaTranscriptionTask.create!(medium:, job: @job) if medium.transcribable?
 
-    body = task ? task.process { service.generate_transcript } : service.generate_transcript
+    body = medium.transcribable? ? task.process { service.generate_transcript } : service.generate_transcript
     service.save_doc(body)
   end
 

--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -4,10 +4,26 @@ class DocGenerationFromMediaJob < ApplicationJob
   queue_as :general
 
   def perform(project, medium, user, attributes)
-    DocGenerationFromMedia.new(project:, medium:, user:, attributes:).call
+    service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
+    task = MediaTranscriptionTask.create!(medium:, job: @job) if transcribable?(medium)
+
+    task&.processing!
+    body = service.generate_transcript
+    task&.succeeded!
+
+    service.save_doc(body)
+  rescue StandardError
+    task.failed! if task && !task.succeeded?
+    raise
   end
 
   def job_name
     'Generate doc text from media'
+  end
+
+  private
+
+  def transcribable?(medium)
+    medium.audio? || medium.video?
   end
 end

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -39,6 +39,6 @@ class MediaTranscriptionTask < ApplicationRecord
   def medium_must_be_audio_or_video
     return unless medium
 
-    errors.add(:medium, 'must be audio or video') unless medium.audio? || medium.video?
+    errors.add(:medium, 'must be audio or video') unless medium.transcribable?
   end
 end

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -34,6 +34,19 @@ class MediaTranscriptionTask < ApplicationRecord
     failed: 'failed'
   }
 
+  # Wraps a transcription attempt, transitioning through processing -> succeeded/failed and
+  # re-raising any error from the block after recording it, so the caller doesn't need to
+  # manage the task's status itself. Mirrors `transaction do ... end`.
+  def process
+    processing!
+    result = yield
+    succeeded!
+    result
+  rescue StandardError
+    failed! unless succeeded?
+    raise
+  end
+
   private
 
   def medium_must_be_audio_or_video

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -16,6 +16,10 @@ class Medium < ApplicationRecord
 
   before_validation :set_media_type_from_content_type
 
+  def transcribable?
+    audio? || video?
+  end
+
   validates :sourcedb, presence: true
   validates :sourceid, presence: true, uniqueness: { scope: :sourcedb }
   validates :media_type, presence: true

--- a/app/services/doc_generation_from_media.rb
+++ b/app/services/doc_generation_from_media.rb
@@ -6,13 +6,15 @@ class DocGenerationFromMedia
     @attributes = attributes
   end
 
-  def call
+  def generate_transcript
     validate_medium!
 
-    body = @medium.file.open do |file|
+    @medium.file.open do |file|
       generate_text(file.path)
     end
+  end
 
+  def save_doc(body)
     hdoc = Doc.hdoc_normalize!(
       {
         **@attributes,

--- a/spec/jobs/doc_generation_from_media_job_spec.rb
+++ b/spec/jobs/doc_generation_from_media_job_spec.rb
@@ -5,21 +5,85 @@ require 'rails_helper'
 RSpec.describe DocGenerationFromMediaJob, type: :job do
   let(:user) { create(:user) }
   let(:project) { create(:project, user: user) }
-  let(:medium) { create(:medium, user: user) }
   let(:attributes) { { sourcedb: 'Example', sourceid: '001' } }
 
   describe '#perform' do
-    let(:generation) { instance_double(DocGenerationFromMedia, call: nil) }
+    let(:generation) { instance_double(DocGenerationFromMedia, generate_transcript: 'A generated transcript.', save_doc: nil) }
 
     before do
       allow(DocGenerationFromMedia).to receive(:new).and_return(generation)
     end
 
-    it 'delegates to DocGenerationFromMedia with the given project, medium, user and attributes' do
-      DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+    context 'with an image medium' do
+      let(:medium) { create(:medium, user: user, media_type: :image, content_type: 'image/png') }
 
-      expect(DocGenerationFromMedia).to have_received(:new).with(project:, medium:, user:, attributes:)
-      expect(generation).to have_received(:call)
+      it 'delegates to DocGenerationFromMedia with the given project, medium, user and attributes' do
+        DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+
+        expect(DocGenerationFromMedia).to have_received(:new).with(project:, medium:, user:, attributes:)
+        expect(generation).to have_received(:generate_transcript)
+        expect(generation).to have_received(:save_doc).with('A generated transcript.')
+      end
+
+      it 'does not create a MediaTranscriptionTask' do
+        expect {
+          DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+        }.not_to change(MediaTranscriptionTask, :count)
+      end
+    end
+
+    context 'with an audio medium' do
+      let(:medium) { create(:medium, user: user, media_type: :audio, content_type: 'audio/mpeg') }
+
+      it 'creates a MediaTranscriptionTask and marks it succeeded' do
+        DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+
+        task = MediaTranscriptionTask.find_by(medium: medium)
+        expect(task).to be_present
+        expect(task).to be_succeeded
+      end
+
+      context 'when generating the transcript fails' do
+        before do
+          allow(generation).to receive(:generate_transcript).and_raise(StandardError, 'transcription blew up')
+        end
+
+        it 'marks the task failed and re-raises' do
+          expect {
+            DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+          }.to raise_error(StandardError, 'transcription blew up')
+
+          task = MediaTranscriptionTask.find_by(medium: medium)
+          expect(task).to be_failed
+        end
+      end
+
+      context 'when saving the doc fails after a successful transcript' do
+        before do
+          allow(generation).to receive(:save_doc).and_raise(StandardError, 'doc save blew up')
+        end
+
+        it 'leaves the task succeeded and re-raises' do
+          expect {
+            DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+          }.to raise_error(StandardError, 'doc save blew up')
+
+          task = MediaTranscriptionTask.find_by(medium: medium)
+          expect(task).to be_succeeded
+        end
+      end
+    end
+
+    context 'with a video medium' do
+      let(:medium) { create(:medium, user: user, media_type: :video, content_type: 'video/mp4') }
+
+      it 'creates a MediaTranscriptionTask and marks it succeeded' do
+        DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+
+        task = MediaTranscriptionTask.find_by(medium: medium)
+        expect(task).to be_present
+        expect(task).to be_succeeded
+      end
     end
   end
 

--- a/spec/models/media_transcription_task_spec.rb
+++ b/spec/models/media_transcription_task_spec.rb
@@ -70,6 +70,40 @@ RSpec.describe MediaTranscriptionTask, type: :model do
     end
   end
 
+  describe '#process' do
+    it 'transitions to processing then succeeded, and returns the block value' do
+      task = create(:media_transcription_task)
+
+      result = task.process { 'transcribed text' }
+
+      expect(result).to eq('transcribed text')
+      expect(task).to be_succeeded
+    end
+
+    it 'transitions to failed and re-raises when the block raises' do
+      task = create(:media_transcription_task)
+
+      expect {
+        task.process { raise StandardError, 'boom' }
+      }.to raise_error(StandardError, 'boom')
+
+      expect(task).to be_failed
+    end
+
+    it 'does not overwrite an already-succeeded status if failed! itself raises' do
+      task = create(:media_transcription_task)
+
+      expect {
+        task.process do
+          task.update!(status: 'succeeded')
+          raise StandardError, 'boom after succeeding'
+        end
+      }.to raise_error(StandardError, 'boom after succeeding')
+
+      expect(task.reload).to be_succeeded
+    end
+  end
+
   describe 'status' do
     %w[pending processing succeeded no_speech failed].each do |status|
       it "supports the #{status} status" do

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -70,6 +70,20 @@ RSpec.describe Medium, type: :model do
     end
   end
 
+  describe '#transcribable?' do
+    it 'is true for audio' do
+      expect(build(:medium, media_type: :audio, content_type: 'audio/mpeg')).to be_transcribable
+    end
+
+    it 'is true for video' do
+      expect(build(:medium, media_type: :video, content_type: 'video/mp4')).to be_transcribable
+    end
+
+    it 'is false for image' do
+      expect(build(:medium, media_type: :image, content_type: 'image/png')).not_to be_transcribable
+    end
+  end
+
   describe 'ActiveStorage' do
     it 'has one attached file' do
       expect(Medium.new).to respond_to(:file)

--- a/spec/services/doc_generation_from_media_spec.rb
+++ b/spec/services/doc_generation_from_media_spec.rb
@@ -33,19 +33,20 @@ RSpec.describe DocGenerationFromMedia do
     medium
   end
 
-  describe '#call' do
+  describe 'generating a doc from media' do
     context 'with a valid image medium' do
       before do
         allow(ImageCaptionService).to receive(:new).and_return(instance_double(ImageCaptionService, call: 'A generated caption.'))
       end
 
       it 'creates a doc with the generated caption, linked to the medium and the project' do
-        doc = described_class.new(
+        service = described_class.new(
           project: project,
           medium: image_medium,
           user: user,
           attributes: { source: nil, sourcedb: 'Example', sourceid: '001' }
-        ).call
+        )
+        doc = service.save_doc(service.generate_transcript)
 
         expect(doc).to be_persisted
         expect(doc.body).to eq('A generated caption.')
@@ -62,12 +63,13 @@ RSpec.describe DocGenerationFromMedia do
       end
 
       it 'creates a doc with the generated transcript, linked to the medium and the project' do
-        doc = described_class.new(
+        service = described_class.new(
           project: project,
           medium: audio_medium,
           user: user,
           attributes: { source: nil, sourcedb: 'Example', sourceid: '002' }
-        ).call
+        )
+        doc = service.save_doc(service.generate_transcript)
 
         expect(doc).to be_persisted
         expect(doc.body).to eq('A generated transcript.')
@@ -84,12 +86,13 @@ RSpec.describe DocGenerationFromMedia do
       end
 
       it 'creates a doc with the transcript generated from the video' do
-        doc = described_class.new(
+        service = described_class.new(
           project: project,
           medium: video_medium,
           user: user,
           attributes: { source: nil, sourcedb: 'Example', sourceid: '003' }
-        ).call
+        )
+        doc = service.save_doc(service.generate_transcript)
 
         expect(doc).to be_persisted
         expect(doc.body).to eq('A generated transcript.')
@@ -111,7 +114,7 @@ RSpec.describe DocGenerationFromMedia do
             medium: medium,
             user: user,
             attributes: { source: nil, sourcedb: nil, sourceid: nil }
-          ).call
+          ).generate_transcript
         }.to raise_error(ArgumentError, /Unsupported media type/).and change(Doc, :count).by(0)
       end
     end
@@ -126,7 +129,7 @@ RSpec.describe DocGenerationFromMedia do
             medium: medium_without_file,
             user: user,
             attributes: { source: nil, sourcedb: nil, sourceid: nil }
-          ).call
+          ).generate_transcript
         }.to raise_error(ArgumentError, /no attached file/).and change(Doc, :count).by(0)
       end
     end


### PR DESCRIPTION
## 概要

- DocGenerationFromMediaJob が、文字起こし対象のmedia(画像を除くaudio/video)に対して MediaTranscriptionTask を作成し、試行のライフサイクル(pending → processing → succeeded / failed)を記録するようにしました。
  - taskが failed になるのは文字起こし自体が失敗した場合のみです。文字起こし後のdoc保存段階で失敗した場合は、文字起こし自体は成功しているため succeeded のまま維持されます。これは DocGenerationFromMedia#call を generate_transcript と save_doc(body) に分割し、ジョブ側の rescue を unless task.succeeded? でガードすることで実現しています。
- 分割後、どこからも呼ばれなくなった DocGenerationFromMedia#call を削除しました。
- specの追加と更新を行いました
  - doc_generation_from_media_job_spec
    - audio/videoのみtaskが作られること、成功時の状態遷移、文字起こし段階とdoc保存段階で失敗の扱いが分かれることのテストを追加
  - doc_generation_from_media_spec.rb
    - generate_transcript/save_doc への分割に合わせてspec更新

このPRに含まれないもの

- no_speech はtaskの取りうる状態として定義済みですが、まだどこからもセットされません。「発話なし」の判定には文字起こし結果のsegmentsが必要ですが、現状の文字起こしサービスはまだsegmentsを生成しないためです。これは MediaTranscript の保存対応と合わせて、次のPRで対応します。

## 動作確認

追加分を含む全てのspecがパスすることを確認しました。