### PR TITLE
Generate media transcript

### DIFF
--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -9,7 +9,7 @@ class DocGenerationFromMediaJob < ApplicationJob
     body, segments = task.process { service.generate_transcript }
     return if task.no_speech?
 
-    service.save_doc(body, segments)
+    service.save_doc(body, segments, media_transcription_task: task)
   end
 
   def job_name

--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -7,9 +7,12 @@ class DocGenerationFromMediaJob < ApplicationJob
     service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
     task = MediaTranscriptionTask.create!(medium:, job: @job)
     body, segments = task.process { service.generate_transcript }
-    return if task.no_speech?
 
-    service.save_doc(body, segments, media_transcription_task: task)
+    if task.no_speech?
+      service.save_transcript(segments, media_transcription_task: task)
+    else
+      service.save_doc(body, segments, media_transcription_task: task)
+    end
   end
 
   def job_name

--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -5,7 +5,9 @@ class DocGenerationFromMediaJob < ApplicationJob
 
   def perform(project, medium, user, attributes)
     service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
-    body, segments = MediaTranscriptionTask.create!(medium:, job: @job).process { service.generate_transcript }
+    task = MediaTranscriptionTask.create!(medium:, job: @job)
+    body, segments = task.process { service.generate_transcript }
+    return if task.no_speech?
 
     service.save_doc(body, segments)
   end

--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -5,9 +5,9 @@ class DocGenerationFromMediaJob < ApplicationJob
 
   def perform(project, medium, user, attributes)
     service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
-    body = MediaTranscriptionTask.create!(medium:, job: @job).process { service.generate_transcript }
+    body, segments = MediaTranscriptionTask.create!(medium:, job: @job).process { service.generate_transcript }
 
-    service.save_doc(body)
+    service.save_doc(body, segments)
   end
 
   def job_name

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -39,12 +39,14 @@ class MediaTranscriptionTask < ApplicationRecord
   # manage the task's status itself. Mirrors `transaction do ... end`. The block is expected to
   # return a [body, segments] tuple, as DocGenerationFromMedia#generate_transcript does. segments
   # is nil for media types that don't produce it (e.g. an image caption) — those always succeed.
-  # An empty array means the medium does produce segments (audio/video) but none were detected,
-  # which is classified as no_speech.
+  # An array (empty, or containing only non-speech labels such as "(music)") means the medium
+  # does produce segments (audio/video) but no speech was detected in them, which is classified
+  # as no_speech. Delegates to MediaTranscript#speech? for that check rather than just looking at
+  # emptiness, since Whisper emits segments for non-speech audio events too.
   def process
     processing!
     body, segments = yield
-    no_speech_detected = segments.is_a?(Array) && segments.empty?
+    no_speech_detected = segments.is_a?(Array) && !MediaTranscript.new(segments: segments).speech?
     no_speech_detected ? no_speech! : succeeded!
     [body, segments]
   rescue StandardError

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -34,16 +34,21 @@ class MediaTranscriptionTask < ApplicationRecord
     failed: 'failed'
   }
 
-  # Wraps a transcription attempt, transitioning through processing -> succeeded/failed and
-  # re-raising any error from the block after recording it, so the caller doesn't need to
-  # manage the task's status itself. Mirrors `transaction do ... end`.
+  # Wraps a transcription attempt, transitioning through processing -> succeeded/no_speech/failed
+  # and re-raising any error from the block after recording it, so the caller doesn't need to
+  # manage the task's status itself. Mirrors `transaction do ... end`. The block is expected to
+  # return a [body, segments] tuple, as DocGenerationFromMedia#generate_transcript does. segments
+  # is nil for media types that don't produce it (e.g. an image caption) — those always succeed.
+  # An empty array means the medium does produce segments (audio/video) but none were detected,
+  # which is classified as no_speech.
   def process
     processing!
-    result = yield
-    succeeded!
-    result
+    body, segments = yield
+    no_speech_detected = segments.is_a?(Array) && segments.empty?
+    no_speech_detected ? no_speech! : succeeded!
+    [body, segments]
   rescue StandardError
-    failed! unless succeeded?
+    failed! unless succeeded? || no_speech?
     raise
   end
 end

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -1,4 +1,8 @@
 class AudioTranscriptionService
+  # Each line of whisper-cli's `-np` output looks like:
+  #   [00:00:00.000 --> 00:00:03.500]   Ask not what your country
+  SEGMENT_LINE = /\A\[(\d{2}):(\d{2}):(\d{2})\.(\d{3}) --> (\d{2}):(\d{2}):(\d{2})\.(\d{3})\]\s*(.*)\z/
+
   def initialize(audio_path)
     @audio_path = audio_path
   end
@@ -9,10 +13,50 @@ class AudioTranscriptionService
     cli_path   = ENV.fetch('WHISPER_CLI_PATH', 'whisper-cli')
     model_path = File.expand_path(ENV.fetch('WHISPER_MODEL_PATH'))
 
-    # -np/-nt keep stdout limited to the transcript itself; diagnostics go to stderr.
-    stdout, stderr, status = Open3.capture3(cli_path, '-m', model_path, '-f', @audio_path, '-np', '-nt')
+    # -np keeps stdout limited to the timestamped segment lines; diagnostics go to stderr.
+    stdout, stderr, status = Open3.capture3(cli_path, '-m', model_path, '-f', @audio_path, '-np')
     raise "Whisper transcription failed (status #{status.exitstatus}): #{stderr.strip}" unless status.success?
 
-    stdout.strip
+    segments = parse_segments(stdout)
+    { text: segments.map { |segment| segment['text'] }.join(' '), segments: }
+  end
+
+  private
+
+  def parse_segments(stdout)
+    duration_ms = audio_duration_ms
+
+    stdout.each_line.filter_map do |line|
+      match = SEGMENT_LINE.match(line.strip)
+      next unless match
+
+      start_ms = clamp(timestamp_to_ms(match[1], match[2], match[3], match[4]), duration_ms)
+      end_ms = clamp(timestamp_to_ms(match[5], match[6], match[7], match[8]), duration_ms)
+
+      { 'text' => match[9].strip, 'start_ms' => start_ms, 'end_ms' => end_ms }
+    end
+  end
+
+  def timestamp_to_ms(hours, minutes, seconds, millis)
+    ((hours.to_i * 3600 + minutes.to_i * 60 + seconds.to_i) * 1000) + millis.to_i
+  end
+
+  def clamp(value_ms, duration_ms)
+    return value_ms unless duration_ms
+
+    [value_ms, duration_ms].min
+  end
+
+  # Whisper pads the last segment of a chunk out to its 30s processing window rather than
+  # the audio's actual end, so offsets are clamped against ffprobe's duration. A failed probe
+  # just skips clamping instead of failing the whole transcription.
+  def audio_duration_ms
+    stdout, _stderr, status = Open3.capture3(
+      'ffprobe', '-v', 'error', '-show_entries', 'format=duration',
+      '-of', 'default=noprint_wrappers=1:nokey=1', @audio_path
+    )
+    return nil unless status.success?
+
+    (stdout.strip.to_f * 1000).round
   end
 end

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -48,8 +48,13 @@ class AudioTranscriptionService
   end
 
   # Whisper pads the last segment of a chunk out to its 30s processing window rather than
-  # the audio's actual end, so offsets are clamped against ffprobe's duration. A failed probe
-  # just skips clamping instead of failing the whole transcription.
+  # the audio's actual end, so offsets are clamped against ffprobe's duration. A failed probe,
+  # or one that can't determine the duration (ffprobe exits successfully but prints "N/A" for
+  # some formats), just skips clamping instead of failing the whole transcription. `Float()` is
+  # used instead of `String#to_f` because `to_f` silently accepts garbage like "N/A" or "5abc"
+  # as 0.0/5.0 instead of raising, and 0 is truthy in Ruby so a lenient parse wouldn't even be
+  # caught by a nil check; `finite?` additionally guards against "Infinity"/"NaN", which parse
+  # fine but would otherwise raise FloatDomainError when rounded.
   def audio_duration_ms
     stdout, _stderr, status = Open3.capture3(
       'ffprobe', '-v', 'error', '-show_entries', 'format=duration',
@@ -57,6 +62,11 @@ class AudioTranscriptionService
     )
     return nil unless status.success?
 
-    (stdout.strip.to_f * 1000).round
+    duration_seconds = Float(stdout.strip)
+    return nil unless duration_seconds.finite? && duration_seconds.positive?
+
+    (duration_seconds * 1000).round
+  rescue ArgumentError, TypeError
+    nil
   end
 end

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -7,8 +7,11 @@ class AudioTranscriptionService
     @audio_path = audio_path
   end
 
+  # Silence is a normal (no-speech) outcome, not a failure, so it's reported as an empty
+  # transcript rather than raised — that lets the caller's usual segments-based no_speech
+  # classification handle it instead of misclassifying it as a processing failure.
   def call
-    raise ArgumentError, "Audio file appears to be silent." if AudioSilenceDetector.new(@audio_path).silent?
+    return { text: '', segments: [] } if AudioSilenceDetector.new(@audio_path).silent?
 
     cli_path   = ENV.fetch('WHISPER_CLI_PATH', 'whisper-cli')
     model_path = File.expand_path(ENV.fetch('WHISPER_MODEL_PATH'))

--- a/app/services/doc_generation_from_media.rb
+++ b/app/services/doc_generation_from_media.rb
@@ -14,7 +14,7 @@ class DocGenerationFromMedia
     end
   end
 
-  def save_doc(body)
+  def save_doc(body, segments = nil)
     hdoc = Doc.hdoc_normalize!(
       {
         **@attributes,
@@ -28,6 +28,7 @@ class DocGenerationFromMedia
 
     doc = Doc.store_hdoc!(hdoc)
     @project.add_doc!(doc)
+    MediaTranscript.create!(doc:, segments:) if segments
     doc
   end
 
@@ -35,11 +36,13 @@ class DocGenerationFromMedia
 
   def generate_text(file_path)
     if @medium.image?
-      ImageCaptionService.new(file_path).call
+      [ImageCaptionService.new(file_path).call, nil]
     elsif @medium.audio?
-      AudioTranscriptionService.new(file_path).call
+      result = AudioTranscriptionService.new(file_path).call
+      [result[:text], result[:segments]]
     elsif @medium.video?
-      VideoTranscriptionService.new(file_path).call
+      result = VideoTranscriptionService.new(file_path).call
+      [result[:text], result[:segments]]
     else
       raise ArgumentError, "Unsupported media type: #{@medium.media_type.inspect}"
     end

--- a/app/services/doc_generation_from_media.rb
+++ b/app/services/doc_generation_from_media.rb
@@ -14,7 +14,7 @@ class DocGenerationFromMedia
     end
   end
 
-  def save_doc(body, segments = nil)
+  def save_doc(body, segments = nil, media_transcription_task: nil)
     hdoc = Doc.hdoc_normalize!(
       {
         **@attributes,
@@ -28,7 +28,7 @@ class DocGenerationFromMedia
 
     doc = Doc.store_hdoc!(hdoc)
     @project.add_doc!(doc)
-    MediaTranscript.create!(doc:, segments:) if segments.present?
+    MediaTranscript.create!(doc:, segments:, medium: @medium, media_transcription_task:) if segments.present?
     doc
   end
 

--- a/app/services/doc_generation_from_media.rb
+++ b/app/services/doc_generation_from_media.rb
@@ -14,12 +14,17 @@ class DocGenerationFromMedia
     end
   end
 
+  # segments is nil for media types that don't produce it (e.g. an image caption), in which case
+  # `body` is used as-is. Otherwise the Doc's body is built only from the speech segments, so
+  # non-speech labels Whisper may emit (e.g. "(music)") don't leak into the generated text.
   def save_doc(body, segments = nil, media_transcription_task: nil)
+    doc_body = segments.present? ? MediaTranscript.new(segments: segments).body : body
+
     hdoc = Doc.hdoc_normalize!(
       {
         **@attributes,
         username: @user.username,
-        body:,
+        body: doc_body,
         medium_id: @medium.id
       },
       @user,
@@ -30,6 +35,12 @@ class DocGenerationFromMedia
     @project.add_doc!(doc)
     MediaTranscript.create!(doc:, segments:, medium: @medium, media_transcription_task:) if segments.present?
     doc
+  end
+
+  # For a no_speech result: keeps the segments Whisper produced (e.g. non-speech labels, or none
+  # at all) without creating a Doc, since there's no speech worth turning into one.
+  def save_transcript(segments, media_transcription_task: nil)
+    MediaTranscript.create!(segments:, medium: @medium, media_transcription_task:)
   end
 
   private

--- a/app/services/doc_generation_from_media.rb
+++ b/app/services/doc_generation_from_media.rb
@@ -28,7 +28,7 @@ class DocGenerationFromMedia
 
     doc = Doc.store_hdoc!(hdoc)
     @project.add_doc!(doc)
-    MediaTranscript.create!(doc:, segments:) if segments
+    MediaTranscript.create!(doc:, segments:) if segments.present?
     doc
   end
 

--- a/spec/jobs/doc_generation_from_media_job_spec.rb
+++ b/spec/jobs/doc_generation_from_media_job_spec.rb
@@ -85,13 +85,31 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
       end
 
       context 'when no segments are returned' do
-        let(:generation) { instance_double(DocGenerationFromMedia, generate_transcript: ['', []], save_doc: nil) }
+        let(:generation) { instance_double(DocGenerationFromMedia, generate_transcript: ['', []], save_doc: nil, save_transcript: nil) }
 
-        it 'marks the task no_speech and does not save a doc' do
+        it 'marks the task no_speech, saves the transcript, and does not save a doc' do
           DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
 
           task = MediaTranscriptionTask.find_by(medium: medium)
           expect(task).to be_no_speech
+          expect(generation).to have_received(:save_transcript).with([], media_transcription_task: task)
+          expect(generation).not_to have_received(:save_doc)
+        end
+      end
+
+      context 'when only non-speech segments are returned' do
+        let(:non_speech_segments) { [{ 'text' => '(applause)', 'start_ms' => 0, 'end_ms' => 2000 }] }
+        let(:generation) do
+          instance_double(DocGenerationFromMedia, generate_transcript: ['(applause)', non_speech_segments], save_doc: nil,
+                                                    save_transcript: nil)
+        end
+
+        it 'marks the task no_speech, saves the transcript, and does not save a doc' do
+          DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+
+          task = MediaTranscriptionTask.find_by(medium: medium)
+          expect(task).to be_no_speech
+          expect(generation).to have_received(:save_transcript).with(non_speech_segments, media_transcription_task: task)
           expect(generation).not_to have_received(:save_doc)
         end
       end

--- a/spec/jobs/doc_generation_from_media_job_spec.rb
+++ b/spec/jobs/doc_generation_from_media_job_spec.rb
@@ -21,9 +21,10 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
       it 'delegates to DocGenerationFromMedia with the given project, medium, user and attributes' do
         DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
 
+        task = MediaTranscriptionTask.find_by(medium: medium)
         expect(DocGenerationFromMedia).to have_received(:new).with(project:, medium:, user:, attributes:)
         expect(generation).to have_received(:generate_transcript)
-        expect(generation).to have_received(:save_doc).with('A generated caption.', nil)
+        expect(generation).to have_received(:save_doc).with('A generated caption.', nil, media_transcription_task: task)
       end
 
       it 'creates a MediaTranscriptionTask and marks it succeeded' do
@@ -49,7 +50,8 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
       it 'saves the doc with the transcript and segments' do
         DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
 
-        expect(generation).to have_received(:save_doc).with('A generated transcript.', segments)
+        task = MediaTranscriptionTask.find_by(medium: medium)
+        expect(generation).to have_received(:save_doc).with('A generated transcript.', segments, media_transcription_task: task)
       end
 
       context 'when generating the transcript fails' do

--- a/spec/jobs/doc_generation_from_media_job_spec.rb
+++ b/spec/jobs/doc_generation_from_media_job_spec.rb
@@ -81,6 +81,18 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
           expect(task).to be_succeeded
         end
       end
+
+      context 'when no segments are returned' do
+        let(:generation) { instance_double(DocGenerationFromMedia, generate_transcript: ['', []], save_doc: nil) }
+
+        it 'marks the task no_speech and does not save a doc' do
+          DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+
+          task = MediaTranscriptionTask.find_by(medium: medium)
+          expect(task).to be_no_speech
+          expect(generation).not_to have_received(:save_doc)
+        end
+      end
     end
 
     context 'with a video medium' do

--- a/spec/jobs/doc_generation_from_media_job_spec.rb
+++ b/spec/jobs/doc_generation_from_media_job_spec.rb
@@ -6,23 +6,24 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
   let(:user) { create(:user) }
   let(:project) { create(:project, user: user) }
   let(:attributes) { { sourcedb: 'Example', sourceid: '001' } }
+  let(:segments) { [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1000 }] }
+  let(:generation) { instance_double(DocGenerationFromMedia, generate_transcript: ['A generated transcript.', segments], save_doc: nil) }
 
   describe '#perform' do
-    let(:generation) { instance_double(DocGenerationFromMedia, generate_transcript: 'A generated transcript.', save_doc: nil) }
-
     before do
       allow(DocGenerationFromMedia).to receive(:new).and_return(generation)
     end
 
     context 'with an image medium' do
       let(:medium) { create(:medium, user: user, media_type: :image, content_type: 'image/png') }
+      let(:generation) { instance_double(DocGenerationFromMedia, generate_transcript: ['A generated caption.', nil], save_doc: nil) }
 
       it 'delegates to DocGenerationFromMedia with the given project, medium, user and attributes' do
         DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
 
         expect(DocGenerationFromMedia).to have_received(:new).with(project:, medium:, user:, attributes:)
         expect(generation).to have_received(:generate_transcript)
-        expect(generation).to have_received(:save_doc).with('A generated transcript.')
+        expect(generation).to have_received(:save_doc).with('A generated caption.', nil)
       end
 
       it 'creates a MediaTranscriptionTask and marks it succeeded' do
@@ -43,6 +44,12 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
         task = MediaTranscriptionTask.find_by(medium: medium)
         expect(task).to be_present
         expect(task).to be_succeeded
+      end
+
+      it 'saves the doc with the transcript and segments' do
+        DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+
+        expect(generation).to have_received(:save_doc).with('A generated transcript.', segments)
       end
 
       context 'when generating the transcript fails' do

--- a/spec/models/media_transcription_task_spec.rb
+++ b/spec/models/media_transcription_task_spec.rb
@@ -80,12 +80,31 @@ RSpec.describe MediaTranscriptionTask, type: :model do
   end
 
   describe '#process' do
-    it 'transitions to processing then succeeded, and returns the block value' do
+    it 'transitions to processing then succeeded when segments are present, and returns the block value' do
+      task = create(:media_transcription_task)
+      segments = [{ 'text' => 'hi', 'start_ms' => 0, 'end_ms' => 100 }]
+
+      result = task.process { ['transcribed text', segments] }
+
+      expect(result).to eq(['transcribed text', segments])
+      expect(task).to be_succeeded
+    end
+
+    it 'transitions to no_speech when the returned segments are an empty array' do
       task = create(:media_transcription_task)
 
-      result = task.process { 'transcribed text' }
+      result = task.process { ['', []] }
 
-      expect(result).to eq('transcribed text')
+      expect(result).to eq(['', []])
+      expect(task).to be_no_speech
+    end
+
+    it 'transitions to succeeded when segments are nil (e.g. an image caption)' do
+      task = create(:media_transcription_task)
+
+      result = task.process { ['a caption', nil] }
+
+      expect(result).to eq(['a caption', nil])
       expect(task).to be_succeeded
     end
 
@@ -110,6 +129,19 @@ RSpec.describe MediaTranscriptionTask, type: :model do
       }.to raise_error(StandardError, 'boom after succeeding')
 
       expect(task.reload).to be_succeeded
+    end
+
+    it 'does not overwrite an already-no_speech status if failed! itself raises' do
+      task = create(:media_transcription_task)
+
+      expect {
+        task.process do
+          task.update!(status: 'no_speech')
+          raise StandardError, 'boom after no_speech'
+        end
+      }.to raise_error(StandardError, 'boom after no_speech')
+
+      expect(task.reload).to be_no_speech
     end
   end
 

--- a/spec/models/media_transcription_task_spec.rb
+++ b/spec/models/media_transcription_task_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe MediaTranscriptionTask, type: :model do
       expect(task).to be_failed
     end
 
-    it 'does not overwrite an already-succeeded status if failed! itself raises' do
+    it 'does not overwrite an already-succeeded status when the block raises after setting succeeded' do
       task = create(:media_transcription_task)
 
       expect {
@@ -131,7 +131,7 @@ RSpec.describe MediaTranscriptionTask, type: :model do
       expect(task.reload).to be_succeeded
     end
 
-    it 'does not overwrite an already-no_speech status if failed! itself raises' do
+    it 'does not overwrite an already-no_speech status when the block raises after setting no_speech' do
       task = create(:media_transcription_task)
 
       expect {

--- a/spec/models/media_transcription_task_spec.rb
+++ b/spec/models/media_transcription_task_spec.rb
@@ -99,6 +99,29 @@ RSpec.describe MediaTranscriptionTask, type: :model do
       expect(task).to be_no_speech
     end
 
+    it 'transitions to no_speech when the returned segments contain only non-speech labels' do
+      task = create(:media_transcription_task)
+      segments = [{ 'text' => '(music)', 'start_ms' => 0, 'end_ms' => 3000 }]
+
+      result = task.process { ['(music)', segments] }
+
+      expect(result).to eq(['(music)', segments])
+      expect(task).to be_no_speech
+    end
+
+    it 'transitions to succeeded when segments mix speech and non-speech labels' do
+      task = create(:media_transcription_task)
+      segments = [
+        { 'text' => '(music)', 'start_ms' => 0, 'end_ms' => 3000 },
+        { 'text' => 'Welcome to the conference.', 'start_ms' => 3000, 'end_ms' => 6000 }
+      ]
+
+      result = task.process { ['(music) Welcome to the conference.', segments] }
+
+      expect(result).to eq(['(music) Welcome to the conference.', segments])
+      expect(task).to be_succeeded
+    end
+
     it 'transitions to succeeded when segments are nil (e.g. an image caption)' do
       task = create(:media_transcription_task)
 

--- a/spec/requests/doc_generations_spec.rb
+++ b/spec/requests/doc_generations_spec.rb
@@ -146,7 +146,12 @@ RSpec.describe 'DocGenerationsController', type: :request do
           content_type: 'video/mp4'
         )
 
-        allow(VideoTranscriptionService).to receive(:new).and_return(instance_double(VideoTranscriptionService, call: 'A generated transcript.'))
+        allow(VideoTranscriptionService).to receive(:new).and_return(
+          instance_double(VideoTranscriptionService, call: {
+            text: 'A generated transcript.',
+            segments: [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1000 }]
+          })
+        )
 
         perform_enqueued_jobs do
           post project_doc_generations_path(project.name),

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -35,11 +35,12 @@ RSpec.describe AudioTranscriptionService do
         allow(AudioSilenceDetector).to receive(:new).with(audio_path).and_return(instance_double(AudioSilenceDetector, silent?: true))
       end
 
-      it 'raises without invoking whisper-cli' do
+      it 'returns an empty transcript without invoking whisper-cli' do
         expect(Open3).not_to receive(:capture3).with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
-        expect {
-          described_class.new(audio_path).call
-        }.to raise_error(ArgumentError, /silent/)
+
+        result = described_class.new(audio_path).call
+
+        expect(result).to eq({ text: '', segments: [] })
       end
     end
 

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -104,6 +104,57 @@ RSpec.describe AudioTranscriptionService do
       end
     end
 
+    context 'when ffprobe succeeds but reports the duration as N/A' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["N/A\n", '', success_status])
+      end
+
+      it 'leaves the raw offsets unclamped instead of collapsing them to 0' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      end
+    end
+
+    context 'when ffprobe succeeds but reports a non-numeric duration' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["5abc\n", '', success_status])
+      end
+
+      it 'leaves the raw offsets unclamped instead of misreading a partial number' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      end
+    end
+
+    context 'when ffprobe succeeds but reports the duration as Infinity' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["Infinity\n", '', success_status])
+      end
+
+      it 'leaves the raw offsets unclamped instead of raising' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      end
+    end
+
     context 'when WHISPER_CLI_PATH overrides the default binary' do
       before do
         ENV['WHISPER_CLI_PATH'] = '/opt/homebrew/bin/whisper-cli'

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -5,6 +5,9 @@ require 'rails_helper'
 RSpec.describe AudioTranscriptionService do
   let(:audio_path) { Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3').to_s }
   let(:model_path) { '/path/to/ggml-base.en.bin' }
+  let(:ffprobe_args) do
+    ['ffprobe', '-v', 'error', '-show_entries', 'format=duration', '-of', 'default=noprint_wrappers=1:nokey=1', audio_path]
+  end
 
   around do |example|
     original_model_path = ENV['WHISPER_MODEL_PATH']
@@ -15,6 +18,11 @@ RSpec.describe AudioTranscriptionService do
   ensure
     ENV['WHISPER_MODEL_PATH'] = original_model_path
     ENV['WHISPER_CLI_PATH'] = original_cli_path
+  end
+
+  def stub_ffprobe(duration_seconds)
+    success_status = instance_double(Process::Status, success?: true)
+    allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["#{duration_seconds}\n", '', success_status])
   end
 
   describe '#call' do
@@ -28,7 +36,7 @@ RSpec.describe AudioTranscriptionService do
       end
 
       it 'raises without invoking whisper-cli' do
-        expect(Open3).not_to receive(:capture3).with('whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
+        expect(Open3).not_to receive(:capture3).with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
         expect {
           described_class.new(audio_path).call
         }.to raise_error(ArgumentError, /silent/)
@@ -38,14 +46,61 @@ RSpec.describe AudioTranscriptionService do
     context 'when whisper-cli succeeds' do
       before do
         success_status = instance_double(Process::Status, success?: true)
+        stdout = <<~TEXT
+          [00:00:00.000 --> 00:00:03.500]   Ask not what your country
+          [00:00:03.500 --> 00:00:06.000]   can do for you.
+        TEXT
         allow(Open3).to receive(:capture3)
-          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
-          .and_return([" Ask not what your country can do for you.\n", '', success_status])
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        stub_ffprobe(6.0)
       end
 
-      it 'returns the transcribed text' do
+      it 'returns the transcribed text with timed segments' do
         result = described_class.new(audio_path).call
-        expect(result).to eq('Ask not what your country can do for you.')
+
+        expect(result[:text]).to eq('Ask not what your country can do for you.')
+        expect(result[:segments]).to eq(
+          [
+            { 'text' => 'Ask not what your country', 'start_ms' => 0, 'end_ms' => 3500 },
+            { 'text' => 'can do for you.', 'start_ms' => 3500, 'end_ms' => 6000 }
+          ]
+        )
+      end
+    end
+
+    context 'when a segment offset overruns the audio duration' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        stub_ffprobe(4.98)
+      end
+
+      it 'clamps start_ms and end_ms to the probed audio duration' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 4980 }])
+      end
+    end
+
+    context 'when ffprobe fails to determine the duration' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        failure_status = instance_double(Process::Status, success?: false)
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(['', 'error', failure_status])
+      end
+
+      it 'leaves the raw offsets unclamped' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
       end
     end
 
@@ -53,14 +108,16 @@ RSpec.describe AudioTranscriptionService do
       before do
         ENV['WHISPER_CLI_PATH'] = '/opt/homebrew/bin/whisper-cli'
         success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:01.000]   transcript\n"
         allow(Open3).to receive(:capture3)
-          .with('/opt/homebrew/bin/whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
-          .and_return(['transcript', '', success_status])
+          .with('/opt/homebrew/bin/whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        stub_ffprobe(1.0)
       end
 
       it 'invokes the configured binary' do
         result = described_class.new(audio_path).call
-        expect(result).to eq('transcript')
+        expect(result[:text]).to eq('transcript')
       end
     end
 
@@ -68,7 +125,7 @@ RSpec.describe AudioTranscriptionService do
       before do
         failure_status = instance_double(Process::Status, success?: false, exitstatus: 2)
         allow(Open3).to receive(:capture3)
-          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
           .and_return(['', "error: input file not found '#{audio_path}'", failure_status])
       end
 

--- a/spec/services/doc_generation_from_media_spec.rb
+++ b/spec/services/doc_generation_from_media_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe DocGenerationFromMedia do
         allow(ImageCaptionService).to receive(:new).and_return(instance_double(ImageCaptionService, call: 'A generated caption.'))
       end
 
-      it 'creates a doc with the generated caption, linked to the medium and the project' do
+      it 'creates a doc with the generated caption, linked to the medium and the project, and no transcript' do
         service = described_class.new(
           project: project,
           medium: image_medium,
           user: user,
           attributes: { source: nil, sourcedb: 'Example', sourceid: '001' }
         )
-        doc = service.save_doc(service.generate_transcript)
+        doc = service.save_doc(*service.generate_transcript)
 
         expect(doc).to be_persisted
         expect(doc.body).to eq('A generated caption.')
@@ -54,12 +54,17 @@ RSpec.describe DocGenerationFromMedia do
         expect(doc.sourceid).to eq('001')
         expect(doc.medium).to eq(image_medium)
         expect(project.docs).to include(doc)
+        expect(doc.media_transcript).to be_nil
       end
     end
 
     context 'with a valid audio medium' do
+      let(:segments) { [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1200 }] }
+
       before do
-        allow(AudioTranscriptionService).to receive(:new).and_return(instance_double(AudioTranscriptionService, call: 'A generated transcript.'))
+        allow(AudioTranscriptionService).to receive(:new).and_return(
+          instance_double(AudioTranscriptionService, call: { text: 'A generated transcript.', segments: segments })
+        )
       end
 
       it 'creates a doc with the generated transcript, linked to the medium and the project' do
@@ -69,7 +74,7 @@ RSpec.describe DocGenerationFromMedia do
           user: user,
           attributes: { source: nil, sourcedb: 'Example', sourceid: '002' }
         )
-        doc = service.save_doc(service.generate_transcript)
+        doc = service.save_doc(*service.generate_transcript)
 
         expect(doc).to be_persisted
         expect(doc.body).to eq('A generated transcript.')
@@ -78,11 +83,29 @@ RSpec.describe DocGenerationFromMedia do
         expect(doc.medium).to eq(audio_medium)
         expect(project.docs).to include(doc)
       end
+
+      it 'creates a MediaTranscript with the returned segments' do
+        service = described_class.new(
+          project: project,
+          medium: audio_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '002' }
+        )
+        doc = service.save_doc(*service.generate_transcript)
+
+        expect(doc.media_transcript).to be_present
+        expect(doc.media_transcript.medium).to eq(audio_medium)
+        expect(doc.media_transcript.segments).to eq(segments)
+      end
     end
 
     context 'with a valid video medium' do
+      let(:segments) { [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1200 }] }
+
       before do
-        allow(VideoTranscriptionService).to receive(:new).and_return(instance_double(VideoTranscriptionService, call: 'A generated transcript.'))
+        allow(VideoTranscriptionService).to receive(:new).and_return(
+          instance_double(VideoTranscriptionService, call: { text: 'A generated transcript.', segments: segments })
+        )
       end
 
       it 'creates a doc with the transcript generated from the video' do
@@ -92,7 +115,7 @@ RSpec.describe DocGenerationFromMedia do
           user: user,
           attributes: { source: nil, sourcedb: 'Example', sourceid: '003' }
         )
-        doc = service.save_doc(service.generate_transcript)
+        doc = service.save_doc(*service.generate_transcript)
 
         expect(doc).to be_persisted
         expect(doc.body).to eq('A generated transcript.')
@@ -100,6 +123,20 @@ RSpec.describe DocGenerationFromMedia do
         expect(doc.sourceid).to eq('003')
         expect(doc.medium).to eq(video_medium)
         expect(project.docs).to include(doc)
+      end
+
+      it 'creates a MediaTranscript with the returned segments' do
+        service = described_class.new(
+          project: project,
+          medium: video_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '003' }
+        )
+        doc = service.save_doc(*service.generate_transcript)
+
+        expect(doc.media_transcript).to be_present
+        expect(doc.media_transcript.medium).to eq(video_medium)
+        expect(doc.media_transcript.segments).to eq(segments)
       end
     end
 

--- a/spec/services/doc_generation_from_media_spec.rb
+++ b/spec/services/doc_generation_from_media_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe DocGenerationFromMedia do
 
     context 'with a valid audio medium' do
       let(:segments) { [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1200 }] }
+      let(:service) do
+        described_class.new(
+          project: project,
+          medium: audio_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '002' }
+        )
+      end
+      let(:doc) { service.save_doc(*service.generate_transcript) }
 
       before do
         allow(AudioTranscriptionService).to receive(:new).and_return(
@@ -68,14 +77,6 @@ RSpec.describe DocGenerationFromMedia do
       end
 
       it 'creates a doc with the generated transcript, linked to the medium and the project' do
-        service = described_class.new(
-          project: project,
-          medium: audio_medium,
-          user: user,
-          attributes: { source: nil, sourcedb: 'Example', sourceid: '002' }
-        )
-        doc = service.save_doc(*service.generate_transcript)
-
         expect(doc).to be_persisted
         expect(doc.body).to eq('A generated transcript.')
         expect(doc.sourcedb).to eq("Example@#{user.username}")
@@ -85,14 +86,6 @@ RSpec.describe DocGenerationFromMedia do
       end
 
       it 'creates a MediaTranscript with the returned segments' do
-        service = described_class.new(
-          project: project,
-          medium: audio_medium,
-          user: user,
-          attributes: { source: nil, sourcedb: 'Example', sourceid: '002' }
-        )
-        doc = service.save_doc(*service.generate_transcript)
-
         expect(doc.media_transcript).to be_present
         expect(doc.media_transcript.medium).to eq(audio_medium)
         expect(doc.media_transcript.segments).to eq(segments)
@@ -101,6 +94,15 @@ RSpec.describe DocGenerationFromMedia do
 
     context 'with a valid video medium' do
       let(:segments) { [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1200 }] }
+      let(:service) do
+        described_class.new(
+          project: project,
+          medium: video_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '003' }
+        )
+      end
+      let(:doc) { service.save_doc(*service.generate_transcript) }
 
       before do
         allow(VideoTranscriptionService).to receive(:new).and_return(
@@ -109,14 +111,6 @@ RSpec.describe DocGenerationFromMedia do
       end
 
       it 'creates a doc with the transcript generated from the video' do
-        service = described_class.new(
-          project: project,
-          medium: video_medium,
-          user: user,
-          attributes: { source: nil, sourcedb: 'Example', sourceid: '003' }
-        )
-        doc = service.save_doc(*service.generate_transcript)
-
         expect(doc).to be_persisted
         expect(doc.body).to eq('A generated transcript.')
         expect(doc.sourcedb).to eq("Example@#{user.username}")
@@ -126,14 +120,6 @@ RSpec.describe DocGenerationFromMedia do
       end
 
       it 'creates a MediaTranscript with the returned segments' do
-        service = described_class.new(
-          project: project,
-          medium: video_medium,
-          user: user,
-          attributes: { source: nil, sourcedb: 'Example', sourceid: '003' }
-        )
-        doc = service.save_doc(*service.generate_transcript)
-
         expect(doc.media_transcript).to be_present
         expect(doc.media_transcript.medium).to eq(video_medium)
         expect(doc.media_transcript.segments).to eq(segments)

--- a/spec/services/doc_generation_from_media_spec.rb
+++ b/spec/services/doc_generation_from_media_spec.rb
@@ -92,6 +92,28 @@ RSpec.describe DocGenerationFromMedia do
       end
     end
 
+    context 'when the transcript mixes speech and non-speech segments' do
+      let(:segments) do
+        [
+          { 'text' => '(music)', 'start_ms' => 0, 'end_ms' => 3000 },
+          { 'text' => 'Welcome to the conference.', 'start_ms' => 3000, 'end_ms' => 6000 }
+        ]
+      end
+
+      it 'builds the doc body from speech segments only, while keeping all segments on the MediaTranscript' do
+        service = described_class.new(
+          project: project,
+          medium: audio_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '006' }
+        )
+        doc = service.save_doc('(music) Welcome to the conference.', segments)
+
+        expect(doc.body).to eq('Welcome to the conference.')
+        expect(doc.media_transcript.segments).to eq(segments)
+      end
+    end
+
     context 'with a valid video medium' do
       let(:segments) { [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1200 }] }
       let(:service) do
@@ -138,6 +160,27 @@ RSpec.describe DocGenerationFromMedia do
 
         expect(doc).to be_persisted
         expect(doc.media_transcript).to be_nil
+      end
+    end
+
+    context 'when save_transcript is called for a no_speech result' do
+      it 'creates a MediaTranscript with the given segments and no doc' do
+        segments = [{ 'text' => '(applause)', 'start_ms' => 0, 'end_ms' => 2000 }]
+        service = described_class.new(
+          project: project,
+          medium: audio_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '007' }
+        )
+
+        expect {
+          service.save_transcript(segments)
+        }.to change(MediaTranscript, :count).by(1).and change(Doc, :count).by(0)
+
+        media_transcript = MediaTranscript.last
+        expect(media_transcript.medium).to eq(audio_medium)
+        expect(media_transcript.segments).to eq(segments)
+        expect(media_transcript.doc).to be_nil
       end
     end
 

--- a/spec/services/doc_generation_from_media_spec.rb
+++ b/spec/services/doc_generation_from_media_spec.rb
@@ -140,6 +140,21 @@ RSpec.describe DocGenerationFromMedia do
       end
     end
 
+    context 'when save_doc is called directly with an empty segments array' do
+      it 'does not create a MediaTranscript' do
+        service = described_class.new(
+          project: project,
+          medium: audio_medium,
+          user: user,
+          attributes: { source: nil, sourcedb: 'Example', sourceid: '005' }
+        )
+        doc = service.save_doc('some transcribed text', [])
+
+        expect(doc).to be_persisted
+        expect(doc.media_transcript).to be_nil
+      end
+    end
+
     context 'when the medium has an unsupported media type' do
       it 'raises without creating a doc' do
         medium = image_medium

--- a/spec/services/video_transcription_service_spec.rb
+++ b/spec/services/video_transcription_service_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe VideoTranscriptionService do
         end
         allow(AudioTranscriptionService).to receive(:new) do |audio_path|
           expect(audio_path).to end_with('.wav')
-          instance_double(AudioTranscriptionService, call: 'A generated transcript.')
+          instance_double(AudioTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
         end
       end
 
       it 'transcribes the audio extracted from the video' do
         result = described_class.new(video_path).call
-        expect(result).to eq('A generated transcript.')
+        expect(result).to eq({ text: 'A generated transcript.', segments: [] })
       end
     end
 


### PR DESCRIPTION
## 概要

- `AudioTranscriptionService` が whisper-cli のタイムスタンプ付き出力をパースし、`{ text:, segments: }` を返すようになりました。
- `DocGenerationFromMedia` がそのsegmentsを save_doc に渡し、生成された Doc と併せて MediaTranscript として保存されるようになりました。
- `DocGenerationFromMediaJob` が `MediaTranscriptionTask#process` を通じて各文字起こし試行を追跡し、pending → processing → succeeded/no_speech/failed の状態遷移を管理できるようになりました。
- 文字起こし結果に発話と判定できるsegmentsが1件もなかった場合（segments自体が空配列、またはWhisperが出力した非発話ラベル（"(music)"等）のみだった場合）はtaskを`no_speech`にし、Docを作成しません。
  - このときも`MediaTranscript`自体は作成され、segmentsには実際にWhisperが返した内容（空配列、または非発話ラベルを含む配列）がそのまま保存されます。
  - 発話と非発話が混在している場合は発話のみがDoc.bodyに保存され、MeidaTranscriptionTaskはsucceedとして保存されます。MediaTranscriptは非発話を含むWhisperの出力をそのまま保存します
 
## 動作確認

- 追加分を含むすべてのspecがパスすることを確認
- ノイズのみの音声を指定してgenerate a new document from mediaでDocを生成しようとすると、MeidaTranscriptTaskとMediaTranscriptは作成されるが、Docは作成されないことを確認
  - MediaTranscriptには文字起こしした生のテキストが、MediaTranscriptTaskにはno_speechとして作成されることを確認

<img width="1043" height="513" alt="スクリーンショット 2026-09-01 10 44 49" src="https://github.com/user-attachments/assets/1d588e12-7a6c-41b7-923f-53f332de4937" />
<img width="828" height="350" alt="スクリーンショット 2026-09-01 10 44 25" src="https://github.com/user-attachments/assets/a3a92e5a-52f1-49b8-a3d8-51ddc46b8c7f" />
<img width="828" height="85" alt="スクリーンショット 2026-09-01 10 50 39" src="https://github.com/user-attachments/assets/3a083875-e23e-4cb4-ae6f-15b4e5894c56" />
