### PR TITLE
Create MediaTranscriptionTask unconditionally, including for images

### DIFF
--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -5,12 +5,7 @@ class DocGenerationFromMediaJob < ApplicationJob
 
   def perform(project, medium, user, attributes)
     service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
-
-    body = if medium.transcribable?
-      MediaTranscriptionTask.create!(medium:, job: @job).process { service.generate_transcript }
-    else
-      service.generate_transcript
-    end
+    body = MediaTranscriptionTask.create!(medium:, job: @job).process { service.generate_transcript }
 
     service.save_doc(body)
   end

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -1,5 +1,5 @@
-# Tracks a single attempt to transcribe one Medium (audio/video only; images are captioned,
-# not transcribed, and have no task). `status` is the machine-readable outcome of that attempt
+# Tracks a single attempt to generate a Doc from one Medium (image caption, audio/video
+# transcription). `status` is the machine-readable outcome of that attempt
 # (pending/processing/succeeded/no_speech/failed), independent of whether the attempt produced
 # a persisted Doc/MediaTranscript. This is what lets "not yet processed" and "processing
 # failed" be told apart, since neither one leaves any other record behind. A Medium may have
@@ -24,7 +24,6 @@ class MediaTranscriptionTask < ApplicationRecord
   belongs_to :job, optional: true
 
   validates :status, presence: true
-  validate :medium_must_be_audio_or_video
 
   enum :status, {
     pending: 'pending',
@@ -45,13 +44,5 @@ class MediaTranscriptionTask < ApplicationRecord
   rescue StandardError
     failed! unless succeeded?
     raise
-  end
-
-  private
-
-  def medium_must_be_audio_or_video
-    return unless medium
-
-    errors.add(:medium, 'must be audio or video') unless medium.transcribable?
   end
 end

--- a/app/models/media_transcription_task.rb
+++ b/app/models/media_transcription_task.rb
@@ -1,10 +1,10 @@
-# Tracks a single attempt to generate a Doc from one Medium (image caption, audio/video
-# transcription). `status` is the machine-readable outcome of that attempt
-# (pending/processing/succeeded/no_speech/failed), independent of whether the attempt produced
-# a persisted Doc/MediaTranscript. This is what lets "not yet processed" and "processing
-# failed" be told apart, since neither one leaves any other record behind. A Medium may have
-# more than one task over time (e.g. a retry after a failure); there is no uniqueness
-# constraint on medium_id.
+# Tracks a single attempt to generate the text (image caption, or audio/video transcript) for
+# one Medium. It does not itself create or persist a Doc — DocGenerationFromMediaJob builds
+# the Doc separately, from the text this attempt produces, so `status` reflects only whether
+# generating that text succeeded, independent of whether a Doc/MediaTranscript ended up
+# persisted. This is what lets "not yet processed" and "processing failed" be told apart,
+# since neither one leaves any other record behind. A Medium may have more than one task over
+# time (e.g. a retry after a failure); there is no uniqueness constraint on medium_id.
 #
 # This is a dedicated resource rather than an extension of Job because Job is a generic,
 # cross-media background-job tracker: it belongs to an organization/Project (not a Medium),

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -16,10 +16,6 @@ class Medium < ApplicationRecord
 
   before_validation :set_media_type_from_content_type
 
-  def transcribable?
-    audio? || video?
-  end
-
   validates :sourcedb, presence: true
   validates :sourceid, presence: true, uniqueness: { scope: :sourcedb }
   validates :media_type, presence: true

--- a/spec/jobs/doc_generation_from_media_job_spec.rb
+++ b/spec/jobs/doc_generation_from_media_job_spec.rb
@@ -25,10 +25,12 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
         expect(generation).to have_received(:save_doc).with('A generated transcript.')
       end
 
-      it 'does not create a MediaTranscriptionTask' do
-        expect {
-          DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
-        }.not_to change(MediaTranscriptionTask, :count)
+      it 'creates a MediaTranscriptionTask and marks it succeeded' do
+        DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
+
+        task = MediaTranscriptionTask.find_by(medium: medium)
+        expect(task).to be_present
+        expect(task).to be_succeeded
       end
     end
 

--- a/spec/models/media_transcription_task_spec.rb
+++ b/spec/models/media_transcription_task_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe MediaTranscriptionTask, type: :model do
       expect(build(:media_transcription_task, status: nil)).not_to be_valid
     end
 
-    it 'rejects a medium whose media_type is image' do
+    it 'accepts an image medium' do
       medium = create(:medium, media_type: :image, content_type: 'image/jpeg')
 
-      expect(build(:media_transcription_task, medium: medium)).not_to be_valid
+      expect(build(:media_transcription_task, medium: medium)).to be_valid
     end
 
     it 'accepts an audio medium' do

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -70,20 +70,6 @@ RSpec.describe Medium, type: :model do
     end
   end
 
-  describe '#transcribable?' do
-    it 'is true for audio' do
-      expect(build(:medium, media_type: :audio, content_type: 'audio/mpeg')).to be_transcribable
-    end
-
-    it 'is true for video' do
-      expect(build(:medium, media_type: :video, content_type: 'video/mp4')).to be_transcribable
-    end
-
-    it 'is false for image' do
-      expect(build(:medium, media_type: :image, content_type: 'image/png')).not_to be_transcribable
-    end
-  end
-
   describe 'ActiveStorage' do
     it 'has one attached file' do
       expect(Medium.new).to respond_to(:file)


### PR DESCRIPTION
## 概要

- DocGenerationFromMediaJob から medium.transcribable? による分岐をなくし、メディア種別(画像/音声/動画)を問わず無条件で MediaTranscriptionTask を作成・追跡するようにしました。
- MediaTranscriptionTask の medium_must_be_audio_or_video バリデーション(audio/videoのみ許容)を削除し、画像も含めた全メディア種別を受け付けるようにしました。
  - コメントも「audio/video限定」という記述を実態に合わせて修正しました。
- Medium#transcribable? は上記2箇所でしか使われておらず、両方不要になったため削除しました。

## 動作確認

- specが全件パスすることを確認

<img width="400" height="400" alt="129414368" src="https://github.com/user-attachments/assets/2919d934-0480-4643-a655-10a02d921031" />

- この画像でgenerate a new document from mediaを行った際、MediaTranscriptionTaskが保存されることを確認

<img width="827" height="559" alt="スクリーンショット 2026-08-28 12 01 32" src="https://github.com/user-attachments/assets/aad7622c-02f7-4fb2-91f8-9c11c04939e6" />

- Ollamaを落とした状態だとMediaTranscriptionTask.statusがfailedで保存されることを確認

<img width="790" height="622" alt="スクリーンショット 2026-08-28 12 02 10" src="https://github.com/user-attachments/assets/a9e2f455-c1a4-4da1-abb6-565e7742c1c3" />
<img width="828" height="157" alt="スクリーンショット 2026-08-28 12 02 24" src="https://github.com/user-attachments/assets/2babc34a-84a8-44a4-9b6b-75f75e5cb59d" />
