### PR TITLE
Extract MediaTextGenerationService from DocGenerationFromMedia

### DIFF
--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -4,7 +4,7 @@ class DocGenerationFromMediaJob < ApplicationJob
   queue_as :general
 
   def perform(project, medium, user, attributes)
-    service = DocGenerationFromMedia.new(project:, medium:, user:, attributes:)
+    service = MediaDocCreationService.new(project:, medium:, user:, attributes:)
     body = MediaTranscriptionTask.create!(medium:, job: @job).process { service.generate_transcript }
 
     service.save_doc(body)

--- a/app/jobs/doc_generation_from_media_job.rb
+++ b/app/jobs/doc_generation_from_media_job.rb
@@ -4,10 +4,11 @@ class DocGenerationFromMediaJob < ApplicationJob
   queue_as :general
 
   def perform(project, medium, user, attributes)
-    service = MediaDocCreationService.new(project:, medium:, user:, attributes:)
-    body = MediaTranscriptionTask.create!(medium:, job: @job).process { service.generate_transcript }
+    task = MediaTranscriptionTask.create!(medium:, job: @job)
 
-    service.save_doc(body)
+    body = task.process { MediaTextGenerationService.new(medium).call }
+
+    MediaDocCreationService.new(project:, medium:, user:, attributes:).save_doc(body)
   end
 
   def job_name

--- a/app/services/media_doc_creation_service.rb
+++ b/app/services/media_doc_creation_service.rb
@@ -6,14 +6,6 @@ class MediaDocCreationService
     @attributes = attributes
   end
 
-  def generate_transcript
-    validate_medium!
-
-    @medium.file.open do |file|
-      generate_text(file.path)
-    end
-  end
-
   def save_doc(body)
     hdoc = Doc.hdoc_normalize!(
       {
@@ -29,23 +21,5 @@ class MediaDocCreationService
     doc = Doc.store_hdoc!(hdoc)
     @project.add_doc!(doc)
     doc
-  end
-
-  private
-
-  def generate_text(file_path)
-    if @medium.image?
-      ImageCaptionService.new(file_path).call
-    elsif @medium.audio?
-      AudioTranscriptionService.new(file_path).call
-    elsif @medium.video?
-      VideoTranscriptionService.new(file_path).call
-    else
-      raise ArgumentError, "Unsupported media type: #{@medium.media_type.inspect}"
-    end
-  end
-
-  def validate_medium!
-    raise ArgumentError, "Specified media has no attached file." unless @medium.file.attached?
   end
 end

--- a/app/services/media_doc_creation_service.rb
+++ b/app/services/media_doc_creation_service.rb
@@ -1,4 +1,4 @@
-class DocGenerationFromMedia
+class MediaDocCreationService
   def initialize(project:, medium:, user:, attributes:)
     @project = project
     @medium = medium

--- a/app/services/media_text_generation_service.rb
+++ b/app/services/media_text_generation_service.rb
@@ -1,0 +1,31 @@
+class MediaTextGenerationService
+  def initialize(medium)
+    @medium = medium
+  end
+
+  def call
+    validate_medium!
+
+    @medium.file.open do |file|
+      generate_text(file.path)
+    end
+  end
+
+  private
+
+  def generate_text(file_path)
+    if @medium.image?
+      ImageCaptionService.new(file_path).call
+    elsif @medium.audio?
+      AudioTranscriptionService.new(file_path).call
+    elsif @medium.video?
+      VideoTranscriptionService.new(file_path).call
+    else
+      raise ArgumentError, "Unsupported media type: #{@medium.media_type.inspect}"
+    end
+  end
+
+  def validate_medium!
+    raise ArgumentError, "Specified media has no attached file." unless @medium.file.attached?
+  end
+end

--- a/spec/jobs/doc_generation_from_media_job_spec.rb
+++ b/spec/jobs/doc_generation_from_media_job_spec.rb
@@ -8,21 +8,24 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
   let(:attributes) { { sourcedb: 'Example', sourceid: '001' } }
 
   describe '#perform' do
-    let(:generation) { instance_double(MediaDocCreationService, generate_transcript: 'A generated transcript.', save_doc: nil) }
+    let(:text_generation) { instance_double(MediaTextGenerationService, call: 'A generated transcript.') }
+    let(:doc_creation) { instance_double(MediaDocCreationService, save_doc: nil) }
 
     before do
-      allow(MediaDocCreationService).to receive(:new).and_return(generation)
+      allow(MediaTextGenerationService).to receive(:new).and_return(text_generation)
+      allow(MediaDocCreationService).to receive(:new).and_return(doc_creation)
     end
 
     context 'with an image medium' do
       let(:medium) { create(:medium, user: user, media_type: :image, content_type: 'image/png') }
 
-      it 'delegates to MediaDocCreationService with the given project, medium, user and attributes' do
+      it 'delegates text generation to MediaTextGenerationService and doc creation to MediaDocCreationService' do
         DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
 
+        expect(MediaTextGenerationService).to have_received(:new).with(medium)
+        expect(text_generation).to have_received(:call)
         expect(MediaDocCreationService).to have_received(:new).with(project:, medium:, user:, attributes:)
-        expect(generation).to have_received(:generate_transcript)
-        expect(generation).to have_received(:save_doc).with('A generated transcript.')
+        expect(doc_creation).to have_received(:save_doc).with('A generated transcript.')
       end
 
       it 'creates a MediaTranscriptionTask and marks it succeeded' do
@@ -45,9 +48,9 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
         expect(task).to be_succeeded
       end
 
-      context 'when generating the transcript fails' do
+      context 'when generating the text fails' do
         before do
-          allow(generation).to receive(:generate_transcript).and_raise(StandardError, 'transcription blew up')
+          allow(text_generation).to receive(:call).and_raise(StandardError, 'transcription blew up')
         end
 
         it 'marks the task failed and re-raises' do
@@ -60,9 +63,9 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
         end
       end
 
-      context 'when saving the doc fails after a successful transcript' do
+      context 'when saving the doc fails after successfully generating text' do
         before do
-          allow(generation).to receive(:save_doc).and_raise(StandardError, 'doc save blew up')
+          allow(doc_creation).to receive(:save_doc).and_raise(StandardError, 'doc save blew up')
         end
 
         it 'leaves the task succeeded and re-raises' do

--- a/spec/jobs/doc_generation_from_media_job_spec.rb
+++ b/spec/jobs/doc_generation_from_media_job_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe DocGenerationFromMediaJob, type: :job do
   let(:attributes) { { sourcedb: 'Example', sourceid: '001' } }
 
   describe '#perform' do
-    let(:generation) { instance_double(DocGenerationFromMedia, generate_transcript: 'A generated transcript.', save_doc: nil) }
+    let(:generation) { instance_double(MediaDocCreationService, generate_transcript: 'A generated transcript.', save_doc: nil) }
 
     before do
-      allow(DocGenerationFromMedia).to receive(:new).and_return(generation)
+      allow(MediaDocCreationService).to receive(:new).and_return(generation)
     end
 
     context 'with an image medium' do
       let(:medium) { create(:medium, user: user, media_type: :image, content_type: 'image/png') }
 
-      it 'delegates to DocGenerationFromMedia with the given project, medium, user and attributes' do
+      it 'delegates to MediaDocCreationService with the given project, medium, user and attributes' do
         DocGenerationFromMediaJob.perform_now(project, medium, user, attributes)
 
-        expect(DocGenerationFromMedia).to have_received(:new).with(project:, medium:, user:, attributes:)
+        expect(MediaDocCreationService).to have_received(:new).with(project:, medium:, user:, attributes:)
         expect(generation).to have_received(:generate_transcript)
         expect(generation).to have_received(:save_doc).with('A generated transcript.')
       end

--- a/spec/services/media_doc_creation_service_spec.rb
+++ b/spec/services/media_doc_creation_service_spec.rb
@@ -5,133 +5,25 @@ require 'rails_helper'
 RSpec.describe MediaDocCreationService do
   let(:user) { create(:user).tap { |u| u.confirm } }
   let(:project) { create(:project, user: user) }
-  let(:image_medium) do
-    medium = create(:medium)
-    medium.file.attach(
-      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_image.png')),
-      filename: 'test_image.png',
-      content_type: 'image/png'
-    )
-    medium
-  end
-  let(:audio_medium) do
-    medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
-    medium.file.attach(
-      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3')),
-      filename: 'test_audio.mp3',
-      content_type: 'audio/mpeg'
-    )
-    medium
-  end
-  let(:video_medium) do
-    medium = create(:medium, media_type: :video, content_type: 'video/mp4')
-    medium.file.attach(
-      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_video.mp4')),
-      filename: 'test_video.mp4',
-      content_type: 'video/mp4'
-    )
-    medium
-  end
+  let(:medium) { create(:medium) }
 
-  describe 'generating a doc from media' do
-    context 'with a valid image medium' do
-      before do
-        allow(ImageCaptionService).to receive(:new).and_return(instance_double(ImageCaptionService, call: 'A generated caption.'))
-      end
+  describe '#save_doc' do
+    it 'creates a doc with the given body, linked to the medium and the project' do
+      service = described_class.new(
+        project: project,
+        medium: medium,
+        user: user,
+        attributes: { source: nil, sourcedb: 'Example', sourceid: '001' }
+      )
 
-      it 'creates a doc with the generated caption, linked to the medium and the project' do
-        service = described_class.new(
-          project: project,
-          medium: image_medium,
-          user: user,
-          attributes: { source: nil, sourcedb: 'Example', sourceid: '001' }
-        )
-        doc = service.save_doc(service.generate_transcript)
+      doc = service.save_doc('A generated body.')
 
-        expect(doc).to be_persisted
-        expect(doc.body).to eq('A generated caption.')
-        expect(doc.sourcedb).to eq("Example@#{user.username}")
-        expect(doc.sourceid).to eq('001')
-        expect(doc.medium).to eq(image_medium)
-        expect(project.docs).to include(doc)
-      end
-    end
-
-    context 'with a valid audio medium' do
-      before do
-        allow(AudioTranscriptionService).to receive(:new).and_return(instance_double(AudioTranscriptionService, call: 'A generated transcript.'))
-      end
-
-      it 'creates a doc with the generated transcript, linked to the medium and the project' do
-        service = described_class.new(
-          project: project,
-          medium: audio_medium,
-          user: user,
-          attributes: { source: nil, sourcedb: 'Example', sourceid: '002' }
-        )
-        doc = service.save_doc(service.generate_transcript)
-
-        expect(doc).to be_persisted
-        expect(doc.body).to eq('A generated transcript.')
-        expect(doc.sourcedb).to eq("Example@#{user.username}")
-        expect(doc.sourceid).to eq('002')
-        expect(doc.medium).to eq(audio_medium)
-        expect(project.docs).to include(doc)
-      end
-    end
-
-    context 'with a valid video medium' do
-      before do
-        allow(VideoTranscriptionService).to receive(:new).and_return(instance_double(VideoTranscriptionService, call: 'A generated transcript.'))
-      end
-
-      it 'creates a doc with the transcript generated from the video' do
-        service = described_class.new(
-          project: project,
-          medium: video_medium,
-          user: user,
-          attributes: { source: nil, sourcedb: 'Example', sourceid: '003' }
-        )
-        doc = service.save_doc(service.generate_transcript)
-
-        expect(doc).to be_persisted
-        expect(doc.body).to eq('A generated transcript.')
-        expect(doc.sourcedb).to eq("Example@#{user.username}")
-        expect(doc.sourceid).to eq('003')
-        expect(doc.medium).to eq(video_medium)
-        expect(project.docs).to include(doc)
-      end
-    end
-
-    context 'when the medium has an unsupported media type' do
-      it 'raises without creating a doc' do
-        medium = image_medium
-        allow(medium).to receive_messages(image?: false, audio?: false, video?: false, media_type: nil)
-
-        expect {
-          described_class.new(
-            project: project,
-            medium: medium,
-            user: user,
-            attributes: { source: nil, sourcedb: nil, sourceid: nil }
-          ).generate_transcript
-        }.to raise_error(ArgumentError, /Unsupported media type/).and change(Doc, :count).by(0)
-      end
-    end
-
-    context 'when the medium has no attached file' do
-      let(:medium_without_file) { create(:medium) }
-
-      it 'raises without creating a doc' do
-        expect {
-          described_class.new(
-            project: project,
-            medium: medium_without_file,
-            user: user,
-            attributes: { source: nil, sourcedb: nil, sourceid: nil }
-          ).generate_transcript
-        }.to raise_error(ArgumentError, /no attached file/).and change(Doc, :count).by(0)
-      end
+      expect(doc).to be_persisted
+      expect(doc.body).to eq('A generated body.')
+      expect(doc.sourcedb).to eq("Example@#{user.username}")
+      expect(doc.sourceid).to eq('001')
+      expect(doc.medium).to eq(medium)
+      expect(project.docs).to include(doc)
     end
   end
 end

--- a/spec/services/media_doc_creation_service_spec.rb
+++ b/spec/services/media_doc_creation_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DocGenerationFromMedia do
+RSpec.describe MediaDocCreationService do
   let(:user) { create(:user).tap { |u| u.confirm } }
   let(:project) { create(:project, user: user) }
   let(:image_medium) do

--- a/spec/services/media_text_generation_service_spec.rb
+++ b/spec/services/media_text_generation_service_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MediaTextGenerationService do
+  let(:image_medium) do
+    medium = create(:medium)
+    medium.file.attach(
+      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_image.png')),
+      filename: 'test_image.png',
+      content_type: 'image/png'
+    )
+    medium
+  end
+  let(:audio_medium) do
+    medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
+    medium.file.attach(
+      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3')),
+      filename: 'test_audio.mp3',
+      content_type: 'audio/mpeg'
+    )
+    medium
+  end
+  let(:video_medium) do
+    medium = create(:medium, media_type: :video, content_type: 'video/mp4')
+    medium.file.attach(
+      io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test_video.mp4')),
+      filename: 'test_video.mp4',
+      content_type: 'video/mp4'
+    )
+    medium
+  end
+
+  describe '#call' do
+    context 'with a valid image medium' do
+      before do
+        allow(ImageCaptionService).to receive(:new).and_return(instance_double(ImageCaptionService, call: 'A generated caption.'))
+      end
+
+      it 'returns the generated caption' do
+        result = described_class.new(image_medium).call
+
+        expect(result).to eq('A generated caption.')
+      end
+    end
+
+    context 'with a valid audio medium' do
+      before do
+        allow(AudioTranscriptionService).to receive(:new).and_return(instance_double(AudioTranscriptionService, call: 'A generated transcript.'))
+      end
+
+      it 'returns the generated transcript' do
+        result = described_class.new(audio_medium).call
+
+        expect(result).to eq('A generated transcript.')
+      end
+    end
+
+    context 'with a valid video medium' do
+      before do
+        allow(VideoTranscriptionService).to receive(:new).and_return(instance_double(VideoTranscriptionService, call: 'A generated transcript.'))
+      end
+
+      it 'returns the transcript generated from the video' do
+        result = described_class.new(video_medium).call
+
+        expect(result).to eq('A generated transcript.')
+      end
+    end
+
+    context 'when the medium has an unsupported media type' do
+      it 'raises' do
+        medium = image_medium
+        allow(medium).to receive_messages(image?: false, audio?: false, video?: false, media_type: nil)
+
+        expect {
+          described_class.new(medium).call
+        }.to raise_error(ArgumentError, /Unsupported media type/)
+      end
+    end
+
+    context 'when the medium has no attached file' do
+      let(:medium_without_file) { create(:medium) }
+
+      it 'raises' do
+        expect {
+          described_class.new(medium_without_file).call
+        }.to raise_error(ArgumentError, /no attached file/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

- `DocGenerationFromMedia` が持っていた「メディアからテキストを生成する責務」を `MediaTextGenerationService` に切り出しました。
- 分割後の文書保存だけを担当するクラスは `MediaDocCreationService` にリネームしました


## 動作確認

- 追加分を含むすべてのspecがパスすることを確認