### PR TITLE
Add text column to MediaTranscript and allow image media

### DIFF
--- a/app/models/media_transcript.rb
+++ b/app/models/media_transcript.rb
@@ -10,6 +10,11 @@ class MediaTranscript < ApplicationRecord
   belongs_to :media_transcription_task, optional: true
   belongs_to :doc, optional: true
 
+  # `text` is the plain-text body for this transcript (e.g. an image caption, or the
+  # already-resolved speech transcript for audio/video), used as the generated Doc's body.
+  # It's nullable rather than required: which media types populate it, and how, is up to the
+  # caller that creates this record, not a universal invariant this model enforces.
+  #
   # `segments` is an array of timed transcript segments. Each element is a hash with string keys:
   #   'text'     - String, the transcribed text for the segment (may be blank, or a non-speech
   #                label such as "(music)" — see NonSpeechTextMatcher).
@@ -18,12 +23,12 @@ class MediaTranscript < ApplicationRecord
   # The interval is [start_ms, end_ms) (start inclusive, end exclusive). Segments are ordered
   # chronologically and must not overlap: each segment's start_ms must be >= the previous
   # segment's end_ms. Gaps are allowed (e.g. silence between segments), so consecutive segments
-  # are not required to touch exactly.
+  # are not required to touch exactly. Media types that don't produce segments (e.g. images)
+  # simply leave this at its default empty array.
   # An empty array, or an array containing only non-speech segments, means no speech was
   # detected in the media — see #speech?.
   validates :media_transcription_task_id, uniqueness: true, allow_nil: true
   validates :doc_id, uniqueness: true, allow_nil: true
-  validate :medium_not_image
   validate :doc_has_matching_medium
   validate :segments_are_valid
 
@@ -42,15 +47,7 @@ class MediaTranscript < ApplicationRecord
     speech_segments.any?
   end
 
-  def body
-    speech_segments.pluck('text').join(' ')
-  end
-
   private
-
-  def medium_not_image
-    errors.add(:medium, 'must not be an image') if medium&.image?
-  end
 
   def doc_has_matching_medium
     errors.add(:doc, 'must have the same medium as this transcript') if doc && doc.medium != medium

--- a/app/models/media_transcript.rb
+++ b/app/models/media_transcript.rb
@@ -47,6 +47,10 @@ class MediaTranscript < ApplicationRecord
     speech_segments.any?
   end
 
+  def speech_text
+    speech_segments.pluck('text').join(' ')
+  end
+
   private
 
   def doc_has_matching_medium

--- a/db/migrate/20260909045333_add_text_to_media_transcripts.rb
+++ b/db/migrate/20260909045333_add_text_to_media_transcripts.rb
@@ -1,0 +1,5 @@
+class AddTextToMediaTranscripts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :media_transcripts, :text, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_075541) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_09_045333) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -307,6 +307,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_075541) do
     t.bigint "media_transcription_task_id"
     t.bigint "medium_id", null: false
     t.json "segments", default: [], null: false
+    t.text "text"
     t.datetime "updated_at", null: false
     t.index ["doc_id"], name: "index_media_transcripts_on_doc_id", unique: true
     t.index ["media_transcription_task_id"], name: "index_media_transcripts_on_media_transcription_task_id", unique: true

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -49,10 +49,10 @@ RSpec.describe MediaTranscript, type: :model do
       expect(build(:media_transcript, medium: medium, doc: nil)).to be_valid
     end
 
-    it 'rejects a medium whose media_type is image' do
+    it 'accepts a medium whose media_type is image' do
       medium = create(:medium, media_type: :image, content_type: 'image/jpeg')
 
-      expect(build(:media_transcript, medium: medium)).not_to be_valid
+      expect(build(:media_transcript, medium: medium, segments: [], text: 'A generated caption.')).to be_valid
     end
 
     it 'accepts a doc whose medium matches this transcript\'s medium' do
@@ -190,20 +190,21 @@ RSpec.describe MediaTranscript, type: :model do
     end
   end
 
-  describe '#body' do
-    it 'joins the text of only the speech segments' do
-      media_transcript = build(:media_transcript, segments: [
-        { 'text' => '(upbeat music)', 'start_ms' => 0, 'end_ms' => 3000 },
-        { 'text' => 'Welcome to the conference.', 'start_ms' => 3000, 'end_ms' => 6000 }
-      ])
+  describe 'text' do
+    it 'defaults to nil' do
+      medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')
 
-      expect(media_transcript.body).to eq('Welcome to the conference.')
+      media_transcript = MediaTranscript.new(medium: medium)
+
+      expect(media_transcript.text).to be_nil
     end
 
-    it 'is blank when there are no speech segments' do
-      media_transcript = build(:media_transcript, segments: [{ 'text' => '(music)', 'start_ms' => 0, 'end_ms' => 100 }])
+    it 'is valid when blank' do
+      expect(build(:media_transcript, text: nil)).to be_valid
+    end
 
-      expect(media_transcript.body).to eq('')
+    it 'is valid with a value' do
+      expect(build(:media_transcript, text: 'A generated caption.')).to be_valid
     end
   end
 

--- a/spec/models/media_transcript_spec.rb
+++ b/spec/models/media_transcript_spec.rb
@@ -190,6 +190,23 @@ RSpec.describe MediaTranscript, type: :model do
     end
   end
 
+  describe '#speech_text' do
+    it 'joins the text of only the speech segments' do
+      media_transcript = build(:media_transcript, segments: [
+        { 'text' => '(upbeat music)', 'start_ms' => 0, 'end_ms' => 3000 },
+        { 'text' => 'Welcome to the conference.', 'start_ms' => 3000, 'end_ms' => 6000 }
+      ])
+
+      expect(media_transcript.speech_text).to eq('Welcome to the conference.')
+    end
+
+    it 'is blank when there are no speech segments' do
+      media_transcript = build(:media_transcript, segments: [{ 'text' => '(music)', 'start_ms' => 0, 'end_ms' => 100 }])
+
+      expect(media_transcript.speech_text).to eq('')
+    end
+  end
+
   describe 'text' do
     it 'defaults to nil' do
       medium = create(:medium, media_type: :audio, content_type: 'audio/mpeg')


### PR DESCRIPTION
## 概要

`MediaTranscript`の拡張作業のうち、モデル層のみを対象にしたPRです。実際にMediaTranscriptを生成する配線（画像・音声・動画から作成する処理）は別PR（`generate-media-transcript-segments`）で対応します。

- `media_transcripts`に`text`カラムを追加しました（nullable）
  - 画像のcaptionや、既に確定した発話テキストなど、生成されたDocの本文として使われる想定です。
  - `segments`のような`NOT NULL`制約は付けていません
- `medium_not_image`バリデーションを削除し、画像メディアも`MediaTranscript`を持てるようにしました。

## 動作確認

- 追加分を含むすべてのspecがパスすることを確認
