### PR TITLE
Have AudioTranscriptionService return timed segments

### DIFF
--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -10,6 +10,13 @@ class AudioTranscriptionService
   def call
     raise ArgumentError, "Audio file appears to be silent." if AudioSilenceDetector.new(@audio_path).silent?
 
+    segments = parse_segments(transcribe, audio_duration_ms)
+    { text: segments.map { |segment| segment['text'] }.join(' '), segments: }
+  end
+
+  private
+
+  def transcribe
     cli_path   = ENV.fetch('WHISPER_CLI_PATH', 'whisper-cli')
     model_path = File.expand_path(ENV.fetch('WHISPER_MODEL_PATH'))
 
@@ -17,32 +24,7 @@ class AudioTranscriptionService
     stdout, stderr, status = Open3.capture3(cli_path, '-m', model_path, '-f', @audio_path, '-np')
     raise "Whisper transcription failed (status #{status.exitstatus}): #{stderr.strip}" unless status.success?
 
-    segments = parse_segments(stdout)
-    { text: segments.map { |segment| segment['text'] }.join(' '), segments: }
-  end
-
-  private
-
-  def parse_segments(stdout)
-    duration_ms = audio_duration_ms
-
-    stdout.each_line.filter_map do |line|
-      match = SEGMENT_LINE.match(line.strip)
-      next unless match
-
-      start_ms = clamp(timestamp_to_ms(match[1], match[2], match[3], match[4]), duration_ms)
-      end_ms = clamp(timestamp_to_ms(match[5], match[6], match[7], match[8]), duration_ms)
-
-      { 'text' => match[9].strip, 'start_ms' => start_ms, 'end_ms' => end_ms }
-    end
-  end
-
-  def timestamp_to_ms(hours, minutes, seconds, millis)
-    ((hours.to_i * 3600 + minutes.to_i * 60 + seconds.to_i) * 1000) + millis.to_i
-  end
-
-  def clamp(value_ms, duration_ms)
-    [value_ms, duration_ms].min
+    stdout
   end
 
   # Whisper pads the last segment of a chunk out to its 30s processing window rather than
@@ -62,5 +44,25 @@ class AudioTranscriptionService
     raise "ffprobe reported an invalid audio duration: #{stdout.strip.inspect}" unless duration_seconds.finite? && duration_seconds.positive?
 
     (duration_seconds * 1000).round
+  end
+
+  def parse_segments(stdout, duration_ms)
+    stdout.each_line.filter_map do |line|
+      match = SEGMENT_LINE.match(line.strip)
+      next unless match
+
+      start_ms = clamp(timestamp_to_ms(match[1], match[2], match[3], match[4]), duration_ms)
+      end_ms = clamp(timestamp_to_ms(match[5], match[6], match[7], match[8]), duration_ms)
+
+      { 'text' => match[9].strip, 'start_ms' => start_ms, 'end_ms' => end_ms }
+    end
+  end
+
+  def timestamp_to_ms(hours, minutes, seconds, millis)
+    ((hours.to_i * 3600 + minutes.to_i * 60 + seconds.to_i) * 1000) + millis.to_i
+  end
+
+  def clamp(value_ms, duration_ms)
+    [value_ms, duration_ms].min
   end
 end

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -61,7 +61,7 @@ class AudioTranscriptionService
       segments << { 'text' => match[9].strip, 'start_ms' => start_ms, 'end_ms' => end_ms }
     end
 
-    segments.sort_by { |segment| segment['start_ms'] }
+    segments
   end
 
   def timestamp_to_ms(hours, minutes, seconds, millis)

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -46,6 +46,8 @@ class AudioTranscriptionService
     raise DurationDetectionError, "ffprobe reported an invalid audio duration: #{stdout.strip.inspect}" unless duration_seconds.finite? && duration_seconds.positive?
 
     (duration_seconds * 1000).round
+  rescue ArgumentError => e
+    raise DurationDetectionError, e.message
   end
 
   def parse_segments(stdout, duration_ms)

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -1,4 +1,7 @@
 class AudioTranscriptionService
+  class TranscriptionError < StandardError; end
+  class DurationDetectionError < StandardError; end
+
   # Each line of whisper-cli's `-np` output looks like:
   #   [00:00:00.000 --> 00:00:03.500]   Ask not what your country
   SEGMENT_LINE = /\A\[(\d{2}):(\d{2}):(\d{2})\.(\d{3}) --> (\d{2}):(\d{2}):(\d{2})\.(\d{3})\]\s*(.*)\z/
@@ -21,7 +24,7 @@ class AudioTranscriptionService
 
     # -np keeps stdout limited to the timestamped segment lines; diagnostics go to stderr.
     stdout, stderr, status = Open3.capture3(cli_path, '-m', model_path, '-f', @audio_path, '-np')
-    raise "Whisper transcription failed (status #{status.exitstatus}): #{stderr.strip}" unless status.success?
+    raise TranscriptionError, "Whisper transcription failed (status #{status.exitstatus}): #{stderr.strip}" unless status.success?
 
     stdout
   end
@@ -37,10 +40,10 @@ class AudioTranscriptionService
       'ffprobe', '-v', 'error', '-show_entries', 'format=duration',
       '-of', 'default=noprint_wrappers=1:nokey=1', @audio_path
     )
-    raise "Failed to determine audio duration via ffprobe (status #{status.exitstatus}): #{stderr.strip}" unless status.success?
+    raise DurationDetectionError, "Failed to determine audio duration via ffprobe (status #{status.exitstatus}): #{stderr.strip}" unless status.success?
 
     duration_seconds = Float(stdout.strip)
-    raise "ffprobe reported an invalid audio duration: #{stdout.strip.inspect}" unless duration_seconds.finite? && duration_seconds.positive?
+    raise DurationDetectionError, "ffprobe reported an invalid audio duration: #{stdout.strip.inspect}" unless duration_seconds.finite? && duration_seconds.positive?
 
     (duration_seconds * 1000).round
   end

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -47,15 +47,22 @@ class AudioTranscriptionService
   end
 
   def parse_segments(stdout, duration_ms)
-    stdout.each_line.filter_map do |line|
+    segments = []
+
+    stdout.each_line do |line|
       match = SEGMENT_LINE.match(line.strip)
       next unless match
 
-      start_ms = clamp(timestamp_to_ms(match[1], match[2], match[3], match[4]), duration_ms)
-      end_ms = clamp(timestamp_to_ms(match[5], match[6], match[7], match[8]), duration_ms)
+      start_ms = timestamp_to_ms(match[1], match[2], match[3], match[4])
+      # Whisper output is normally chronological, so once a segment starts past the audio's
+      # actual end there's nothing legitimate left to parse.
+      break if start_ms > duration_ms
 
-      { 'text' => match[9].strip, 'start_ms' => start_ms, 'end_ms' => end_ms }
-    end.sort_by { |segment| segment['start_ms'] }
+      end_ms = clamp(timestamp_to_ms(match[5], match[6], match[7], match[8]), duration_ms)
+      segments << { 'text' => match[9].strip, 'start_ms' => start_ms, 'end_ms' => end_ms }
+    end
+
+    segments.sort_by { |segment| segment['start_ms'] }
   end
 
   def timestamp_to_ms(hours, minutes, seconds, millis)

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -1,4 +1,8 @@
 class AudioTranscriptionService
+  # Each line of whisper-cli's `-np` output looks like:
+  #   [00:00:00.000 --> 00:00:03.500]   Ask not what your country
+  SEGMENT_LINE = /\A\[(\d{2}):(\d{2}):(\d{2})\.(\d{3}) --> (\d{2}):(\d{2}):(\d{2})\.(\d{3})\]\s*(.*)\z/
+
   def initialize(audio_path)
     @audio_path = audio_path
   end
@@ -9,10 +13,62 @@ class AudioTranscriptionService
     cli_path   = ENV.fetch('WHISPER_CLI_PATH', 'whisper-cli')
     model_path = File.expand_path(ENV.fetch('WHISPER_MODEL_PATH'))
 
-    # -np/-nt keep stdout limited to the transcript itself; diagnostics go to stderr.
-    stdout, stderr, status = Open3.capture3(cli_path, '-m', model_path, '-f', @audio_path, '-np', '-nt')
+    # -np keeps stdout limited to the timestamped segment lines; diagnostics go to stderr.
+    stdout, stderr, status = Open3.capture3(cli_path, '-m', model_path, '-f', @audio_path, '-np')
     raise "Whisper transcription failed (status #{status.exitstatus}): #{stderr.strip}" unless status.success?
 
-    stdout.strip
+    segments = parse_segments(stdout)
+    { text: segments.map { |segment| segment['text'] }.join(' '), segments: }
+  end
+
+  private
+
+  def parse_segments(stdout)
+    duration_ms = audio_duration_ms
+
+    stdout.each_line.filter_map do |line|
+      match = SEGMENT_LINE.match(line.strip)
+      next unless match
+
+      start_ms = clamp(timestamp_to_ms(match[1], match[2], match[3], match[4]), duration_ms)
+      end_ms = clamp(timestamp_to_ms(match[5], match[6], match[7], match[8]), duration_ms)
+
+      { 'text' => match[9].strip, 'start_ms' => start_ms, 'end_ms' => end_ms }
+    end
+  end
+
+  def timestamp_to_ms(hours, minutes, seconds, millis)
+    ((hours.to_i * 3600 + minutes.to_i * 60 + seconds.to_i) * 1000) + millis.to_i
+  end
+
+  def clamp(value_ms, duration_ms)
+    return value_ms unless duration_ms
+
+    [value_ms, duration_ms].min
+  end
+
+  # Whisper pads the last segment of a chunk out to its 30s processing window rather than
+  # the audio's actual end, so offsets are clamped against ffprobe's duration. A failed probe,
+  # one that can't determine the duration (ffprobe exits successfully but prints "N/A" for
+  # some formats), or ffprobe not being installed at all, just skips clamping instead of
+  # failing the whole transcription — ffprobe is only ever used here, for this refinement, so
+  # its absence shouldn't block whisper-cli's actual output. `Float()` is used instead of
+  # `String#to_f` because `to_f` silently accepts garbage like "N/A" or "5abc" as 0.0/5.0
+  # instead of raising, and 0 is truthy in Ruby so a lenient parse wouldn't even be caught by a
+  # nil check; `finite?` additionally guards against "Infinity"/"NaN", which parse fine but
+  # would otherwise raise FloatDomainError when rounded.
+  def audio_duration_ms
+    stdout, _stderr, status = Open3.capture3(
+      'ffprobe', '-v', 'error', '-show_entries', 'format=duration',
+      '-of', 'default=noprint_wrappers=1:nokey=1', @audio_path
+    )
+    return nil unless status.success?
+
+    duration_seconds = Float(stdout.strip)
+    return nil unless duration_seconds.finite? && duration_seconds.positive?
+
+    (duration_seconds * 1000).round
+  rescue ArgumentError, TypeError, SystemCallError
+    nil
   end
 end

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -55,7 +55,7 @@ class AudioTranscriptionService
       end_ms = clamp(timestamp_to_ms(match[5], match[6], match[7], match[8]), duration_ms)
 
       { 'text' => match[9].strip, 'start_ms' => start_ms, 'end_ms' => end_ms }
-    end
+    end.sort_by { |segment| segment['start_ms'] }
   end
 
   def timestamp_to_ms(hours, minutes, seconds, millis)

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -10,8 +10,7 @@ class AudioTranscriptionService
   def call
     raise ArgumentError, "Audio file appears to be silent." if AudioSilenceDetector.new(@audio_path).silent?
 
-    segments = parse_segments(transcribe, audio_duration_ms)
-    { text: segments.map { |segment| segment['text'] }.join(' '), segments: }
+    parse_segments(transcribe, audio_duration_ms)
   end
 
   private

--- a/app/services/audio_transcription_service.rb
+++ b/app/services/audio_transcription_service.rb
@@ -42,33 +42,25 @@ class AudioTranscriptionService
   end
 
   def clamp(value_ms, duration_ms)
-    return value_ms unless duration_ms
-
     [value_ms, duration_ms].min
   end
 
   # Whisper pads the last segment of a chunk out to its 30s processing window rather than
-  # the audio's actual end, so offsets are clamped against ffprobe's duration. A failed probe,
-  # one that can't determine the duration (ffprobe exits successfully but prints "N/A" for
-  # some formats), or ffprobe not being installed at all, just skips clamping instead of
-  # failing the whole transcription — ffprobe is only ever used here, for this refinement, so
-  # its absence shouldn't block whisper-cli's actual output. `Float()` is used instead of
-  # `String#to_f` because `to_f` silently accepts garbage like "N/A" or "5abc" as 0.0/5.0
-  # instead of raising, and 0 is truthy in Ruby so a lenient parse wouldn't even be caught by a
-  # nil check; `finite?` additionally guards against "Infinity"/"NaN", which parse fine but
-  # would otherwise raise FloatDomainError when rounded.
+  # the audio's actual end, so offsets are clamped against ffprobe's duration. `Float()` is
+  # used instead of `String#to_f` because `to_f` silently accepts garbage like "N/A" or
+  # "5abc" as 0.0/5.0 instead of raising, and 0 is truthy in Ruby so a lenient parse wouldn't
+  # even be caught by a nil check; `finite?` additionally guards against "Infinity"/"NaN",
+  # which parse fine but would otherwise raise FloatDomainError when rounded.
   def audio_duration_ms
-    stdout, _stderr, status = Open3.capture3(
+    stdout, stderr, status = Open3.capture3(
       'ffprobe', '-v', 'error', '-show_entries', 'format=duration',
       '-of', 'default=noprint_wrappers=1:nokey=1', @audio_path
     )
-    return nil unless status.success?
+    raise "Failed to determine audio duration via ffprobe (status #{status.exitstatus}): #{stderr.strip}" unless status.success?
 
     duration_seconds = Float(stdout.strip)
-    return nil unless duration_seconds.finite? && duration_seconds.positive?
+    raise "ffprobe reported an invalid audio duration: #{stdout.strip.inspect}" unless duration_seconds.finite? && duration_seconds.positive?
 
     (duration_seconds * 1000).round
-  rescue ArgumentError, TypeError, SystemCallError
-    nil
   end
 end

--- a/app/services/media_text_generation_service.rb
+++ b/app/services/media_text_generation_service.rb
@@ -17,9 +17,9 @@ class MediaTextGenerationService
     if @medium.image?
       ImageCaptionService.new(file_path).call
     elsif @medium.audio?
-      AudioTranscriptionService.new(file_path).call
+      AudioTranscriptionService.new(file_path).call[:text]
     elsif @medium.video?
-      VideoTranscriptionService.new(file_path).call
+      VideoTranscriptionService.new(file_path).call[:text]
     else
       raise ArgumentError, "Unsupported media type: #{@medium.media_type.inspect}"
     end

--- a/app/services/media_text_generation_service.rb
+++ b/app/services/media_text_generation_service.rb
@@ -17,12 +17,17 @@ class MediaTextGenerationService
     if @medium.image?
       ImageCaptionService.new(file_path).call
     elsif @medium.audio?
-      AudioTranscriptionService.new(file_path).call[:text]
+      segments_to_text(AudioTranscriptionService.new(file_path).call)
     elsif @medium.video?
-      VideoTranscriptionService.new(file_path).call[:text]
+      segments_to_text(VideoTranscriptionService.new(file_path).call)
     else
       raise ArgumentError, "Unsupported media type: #{@medium.media_type.inspect}"
     end
+  end
+
+  # Temporary: will be replaced once MediaTranscript builds this from segments itself.
+  def segments_to_text(segments)
+    segments.map { |segment| segment['text'] }.join(' ')
   end
 
   def validate_medium!

--- a/spec/requests/doc_generations_spec.rb
+++ b/spec/requests/doc_generations_spec.rb
@@ -146,7 +146,9 @@ RSpec.describe 'DocGenerationsController', type: :request do
           content_type: 'video/mp4'
         )
 
-        allow(VideoTranscriptionService).to receive(:new).and_return(instance_double(VideoTranscriptionService, call: 'A generated transcript.'))
+        allow(VideoTranscriptionService).to receive(:new).and_return(
+          instance_double(VideoTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
+        )
 
         perform_enqueued_jobs do
           post project_doc_generations_path(project.name),

--- a/spec/requests/doc_generations_spec.rb
+++ b/spec/requests/doc_generations_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe 'DocGenerationsController', type: :request do
         )
 
         allow(VideoTranscriptionService).to receive(:new).and_return(
-          instance_double(VideoTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
+          instance_double(VideoTranscriptionService, call: [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1000 }])
         )
 
         perform_enqueued_jobs do

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -5,6 +5,9 @@ require 'rails_helper'
 RSpec.describe AudioTranscriptionService do
   let(:audio_path) { Rails.root.join('spec', 'fixtures', 'files', 'test_audio.mp3').to_s }
   let(:model_path) { '/path/to/ggml-base.en.bin' }
+  let(:ffprobe_args) do
+    ['ffprobe', '-v', 'error', '-show_entries', 'format=duration', '-of', 'default=noprint_wrappers=1:nokey=1', audio_path]
+  end
 
   around do |example|
     original_model_path = ENV['WHISPER_MODEL_PATH']
@@ -15,6 +18,11 @@ RSpec.describe AudioTranscriptionService do
   ensure
     ENV['WHISPER_MODEL_PATH'] = original_model_path
     ENV['WHISPER_CLI_PATH'] = original_cli_path
+  end
+
+  def stub_ffprobe(duration_seconds)
+    success_status = instance_double(Process::Status, success?: true)
+    allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["#{duration_seconds}\n", '', success_status])
   end
 
   describe '#call' do
@@ -28,7 +36,7 @@ RSpec.describe AudioTranscriptionService do
       end
 
       it 'raises without invoking whisper-cli' do
-        expect(Open3).not_to receive(:capture3).with('whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
+        expect(Open3).not_to receive(:capture3).with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
         expect {
           described_class.new(audio_path).call
         }.to raise_error(ArgumentError, /silent/)
@@ -38,14 +46,129 @@ RSpec.describe AudioTranscriptionService do
     context 'when whisper-cli succeeds' do
       before do
         success_status = instance_double(Process::Status, success?: true)
+        stdout = <<~TEXT
+          [00:00:00.000 --> 00:00:03.500]   Ask not what your country
+          [00:00:03.500 --> 00:00:06.000]   can do for you.
+        TEXT
         allow(Open3).to receive(:capture3)
-          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
-          .and_return([" Ask not what your country can do for you.\n", '', success_status])
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        stub_ffprobe(6.0)
       end
 
-      it 'returns the transcribed text' do
+      it 'returns the transcribed text with timed segments' do
         result = described_class.new(audio_path).call
-        expect(result).to eq('Ask not what your country can do for you.')
+
+        expect(result[:text]).to eq('Ask not what your country can do for you.')
+        expect(result[:segments]).to eq(
+          [
+            { 'text' => 'Ask not what your country', 'start_ms' => 0, 'end_ms' => 3500 },
+            { 'text' => 'can do for you.', 'start_ms' => 3500, 'end_ms' => 6000 }
+          ]
+        )
+      end
+    end
+
+    context 'when a segment offset overruns the audio duration' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        stub_ffprobe(4.98)
+      end
+
+      it 'clamps start_ms and end_ms to the probed audio duration' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 4980 }])
+      end
+    end
+
+    context 'when ffprobe fails to determine the duration' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        failure_status = instance_double(Process::Status, success?: false)
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(['', 'error', failure_status])
+      end
+
+      it 'leaves the raw offsets unclamped' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      end
+    end
+
+    context 'when ffprobe succeeds but reports the duration as N/A' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["N/A\n", '', success_status])
+      end
+
+      it 'leaves the raw offsets unclamped instead of collapsing them to 0' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      end
+    end
+
+    context 'when ffprobe succeeds but reports a non-numeric duration' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["5abc\n", '', success_status])
+      end
+
+      it 'leaves the raw offsets unclamped instead of misreading a partial number' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      end
+    end
+
+    context 'when ffprobe is not installed' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_raise(Errno::ENOENT, 'ffprobe')
+      end
+
+      it 'leaves the raw offsets unclamped instead of failing the whole transcription' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      end
+    end
+
+    context 'when ffprobe succeeds but reports the duration as Infinity' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["Infinity\n", '', success_status])
+      end
+
+      it 'leaves the raw offsets unclamped instead of raising' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
       end
     end
 
@@ -53,14 +176,16 @@ RSpec.describe AudioTranscriptionService do
       before do
         ENV['WHISPER_CLI_PATH'] = '/opt/homebrew/bin/whisper-cli'
         success_status = instance_double(Process::Status, success?: true)
+        stdout = "[00:00:00.000 --> 00:00:01.000]   transcript\n"
         allow(Open3).to receive(:capture3)
-          .with('/opt/homebrew/bin/whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
-          .and_return(['transcript', '', success_status])
+          .with('/opt/homebrew/bin/whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        stub_ffprobe(1.0)
       end
 
       it 'invokes the configured binary' do
         result = described_class.new(audio_path).call
-        expect(result).to eq('transcript')
+        expect(result[:text]).to eq('transcript')
       end
     end
 
@@ -68,7 +193,7 @@ RSpec.describe AudioTranscriptionService do
       before do
         failure_status = instance_double(Process::Status, success?: false, exitstatus: 2)
         allow(Open3).to receive(:capture3)
-          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np', '-nt')
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
           .and_return(['', "error: input file not found '#{audio_path}'", failure_status])
       end
 

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -56,11 +56,10 @@ RSpec.describe AudioTranscriptionService do
         stub_ffprobe(6.0)
       end
 
-      it 'returns the transcribed text with timed segments' do
+      it 'returns the timed segments' do
         result = described_class.new(audio_path).call
 
-        expect(result[:text]).to eq('Ask not what your country can do for you.')
-        expect(result[:segments]).to eq(
+        expect(result).to eq(
           [
             { 'text' => 'Ask not what your country', 'start_ms' => 0, 'end_ms' => 3500 },
             { 'text' => 'can do for you.', 'start_ms' => 3500, 'end_ms' => 6000 }
@@ -85,7 +84,7 @@ RSpec.describe AudioTranscriptionService do
       it 'sorts the segments by start_ms' do
         result = described_class.new(audio_path).call
 
-        expect(result[:segments]).to eq(
+        expect(result).to eq(
           [
             { 'text' => 'Ask not what your country', 'start_ms' => 0, 'end_ms' => 3500 },
             { 'text' => 'can do for you.', 'start_ms' => 3500, 'end_ms' => 6000 }
@@ -107,7 +106,7 @@ RSpec.describe AudioTranscriptionService do
       it 'clamps end_ms to the probed audio duration' do
         result = described_class.new(audio_path).call
 
-        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 4980 }])
+        expect(result).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 4980 }])
       end
     end
 
@@ -127,7 +126,7 @@ RSpec.describe AudioTranscriptionService do
       it 'stops parsing instead of including the trailing out-of-range segment' do
         result = described_class.new(audio_path).call
 
-        expect(result[:segments]).to eq(
+        expect(result).to eq(
           [{ 'text' => 'Ask not what your country', 'start_ms' => 0, 'end_ms' => 3500 }]
         )
       end
@@ -232,7 +231,7 @@ RSpec.describe AudioTranscriptionService do
 
       it 'invokes the configured binary' do
         result = described_class.new(audio_path).call
-        expect(result[:text]).to eq('transcript')
+        expect(result).to eq([{ 'text' => 'transcript', 'start_ms' => 0, 'end_ms' => 1000 }])
       end
     end
 

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -93,14 +93,14 @@ RSpec.describe AudioTranscriptionService do
         allow(Open3).to receive(:capture3)
           .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
           .and_return([stdout, '', success_status])
-        failure_status = instance_double(Process::Status, success?: false)
+        failure_status = instance_double(Process::Status, success?: false, exitstatus: 1)
         allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(['', 'error', failure_status])
       end
 
-      it 'leaves the raw offsets unclamped' do
-        result = described_class.new(audio_path).call
-
-        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      it 'raises instead of returning an unclamped transcription' do
+        expect {
+          described_class.new(audio_path).call
+        }.to raise_error(/Failed to determine audio duration via ffprobe/)
       end
     end
 
@@ -114,10 +114,10 @@ RSpec.describe AudioTranscriptionService do
         allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["N/A\n", '', success_status])
       end
 
-      it 'leaves the raw offsets unclamped instead of collapsing them to 0' do
-        result = described_class.new(audio_path).call
-
-        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      it 'raises instead of collapsing the offsets to 0' do
+        expect {
+          described_class.new(audio_path).call
+        }.to raise_error(ArgumentError)
       end
     end
 
@@ -131,10 +131,10 @@ RSpec.describe AudioTranscriptionService do
         allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["5abc\n", '', success_status])
       end
 
-      it 'leaves the raw offsets unclamped instead of misreading a partial number' do
-        result = described_class.new(audio_path).call
-
-        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      it 'raises instead of misreading a partial number' do
+        expect {
+          described_class.new(audio_path).call
+        }.to raise_error(ArgumentError)
       end
     end
 
@@ -148,27 +148,27 @@ RSpec.describe AudioTranscriptionService do
         allow(Open3).to receive(:capture3).with(*ffprobe_args).and_raise(Errno::ENOENT, 'ffprobe')
       end
 
-      it 'leaves the raw offsets unclamped instead of failing the whole transcription' do
-        result = described_class.new(audio_path).call
-
-        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      it 'raises instead of silently skipping duration clamping' do
+        expect {
+          described_class.new(audio_path).call
+        }.to raise_error(Errno::ENOENT)
       end
     end
 
-    context 'when ffprobe succeeds but reports the duration as Infinity' do
+    context 'when ffprobe succeeds but reports a duration that overflows to Infinity' do
       before do
         success_status = instance_double(Process::Status, success?: true)
         stdout = "[00:00:00.000 --> 00:00:30.000]   Hello world.\n"
         allow(Open3).to receive(:capture3)
           .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
           .and_return([stdout, '', success_status])
-        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["Infinity\n", '', success_status])
+        allow(Open3).to receive(:capture3).with(*ffprobe_args).and_return(["1e400\n", '', success_status])
       end
 
-      it 'leaves the raw offsets unclamped instead of raising' do
-        result = described_class.new(audio_path).call
-
-        expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 30_000 }])
+      it 'raises instead of later raising FloatDomainError from rounding' do
+        expect {
+          described_class.new(audio_path).call
+        }.to raise_error(/ffprobe reported an invalid audio duration/)
       end
     end
 

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -68,31 +68,6 @@ RSpec.describe AudioTranscriptionService do
       end
     end
 
-    context 'when whisper-cli emits segments out of chronological order' do
-      before do
-        success_status = instance_double(Process::Status, success?: true)
-        stdout = <<~TEXT
-          [00:00:03.500 --> 00:00:06.000]   can do for you.
-          [00:00:00.000 --> 00:00:03.500]   Ask not what your country
-        TEXT
-        allow(Open3).to receive(:capture3)
-          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
-          .and_return([stdout, '', success_status])
-        stub_ffprobe(6.0)
-      end
-
-      it 'sorts the segments by start_ms' do
-        result = described_class.new(audio_path).call
-
-        expect(result).to eq(
-          [
-            { 'text' => 'Ask not what your country', 'start_ms' => 0, 'end_ms' => 3500 },
-            { 'text' => 'can do for you.', 'start_ms' => 3500, 'end_ms' => 6000 }
-          ]
-        )
-      end
-    end
-
     context 'when a segment offset overruns the audio duration' do
       before do
         success_status = instance_double(Process::Status, success?: true)

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe AudioTranscriptionService do
       it 'raises instead of returning an unclamped transcription' do
         expect {
           described_class.new(audio_path).call
-        }.to raise_error(/Failed to determine audio duration via ffprobe/)
+        }.to raise_error(AudioTranscriptionService::DurationDetectionError, /Failed to determine audio duration via ffprobe/)
       end
     end
 
@@ -189,7 +189,7 @@ RSpec.describe AudioTranscriptionService do
       it 'raises instead of later raising FloatDomainError from rounding' do
         expect {
           described_class.new(audio_path).call
-        }.to raise_error(/ffprobe reported an invalid audio duration/)
+        }.to raise_error(AudioTranscriptionService::DurationDetectionError, /ffprobe reported an invalid audio duration/)
       end
     end
 
@@ -221,7 +221,7 @@ RSpec.describe AudioTranscriptionService do
       it 'raises an error including the exit status and stderr' do
         expect {
           described_class.new(audio_path).call
-        }.to raise_error(/Whisper transcription failed \(status 2\).*input file not found/)
+        }.to raise_error(AudioTranscriptionService::TranscriptionError, /Whisper transcription failed \(status 2\).*input file not found/)
       end
     end
   end

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe AudioTranscriptionService do
       it 'raises instead of collapsing the offsets to 0' do
         expect {
           described_class.new(audio_path).call
-        }.to raise_error(ArgumentError)
+        }.to raise_error(AudioTranscriptionService::DurationDetectionError)
       end
     end
 
@@ -155,7 +155,7 @@ RSpec.describe AudioTranscriptionService do
       it 'raises instead of misreading a partial number' do
         expect {
           described_class.new(audio_path).call
-        }.to raise_error(ArgumentError)
+        }.to raise_error(AudioTranscriptionService::DurationDetectionError)
       end
     end
 

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -104,10 +104,32 @@ RSpec.describe AudioTranscriptionService do
         stub_ffprobe(4.98)
       end
 
-      it 'clamps start_ms and end_ms to the probed audio duration' do
+      it 'clamps end_ms to the probed audio duration' do
         result = described_class.new(audio_path).call
 
         expect(result[:segments]).to eq([{ 'text' => 'Hello world.', 'start_ms' => 0, 'end_ms' => 4980 }])
+      end
+    end
+
+    context 'when a segment starts entirely past the audio duration' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = <<~TEXT
+          [00:00:00.000 --> 00:00:03.500]   Ask not what your country
+          [00:00:05.000 --> 00:00:06.000]   can do for you.
+        TEXT
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        stub_ffprobe(3.5)
+      end
+
+      it 'stops parsing instead of including the trailing out-of-range segment' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq(
+          [{ 'text' => 'Ask not what your country', 'start_ms' => 0, 'end_ms' => 3500 }]
+        )
       end
     end
 

--- a/spec/services/audio_transcription_service_spec.rb
+++ b/spec/services/audio_transcription_service_spec.rb
@@ -69,6 +69,31 @@ RSpec.describe AudioTranscriptionService do
       end
     end
 
+    context 'when whisper-cli emits segments out of chronological order' do
+      before do
+        success_status = instance_double(Process::Status, success?: true)
+        stdout = <<~TEXT
+          [00:00:03.500 --> 00:00:06.000]   can do for you.
+          [00:00:00.000 --> 00:00:03.500]   Ask not what your country
+        TEXT
+        allow(Open3).to receive(:capture3)
+          .with('whisper-cli', '-m', model_path, '-f', audio_path, '-np')
+          .and_return([stdout, '', success_status])
+        stub_ffprobe(6.0)
+      end
+
+      it 'sorts the segments by start_ms' do
+        result = described_class.new(audio_path).call
+
+        expect(result[:segments]).to eq(
+          [
+            { 'text' => 'Ask not what your country', 'start_ms' => 0, 'end_ms' => 3500 },
+            { 'text' => 'can do for you.', 'start_ms' => 3500, 'end_ms' => 6000 }
+          ]
+        )
+      end
+    end
+
     context 'when a segment offset overruns the audio duration' do
       before do
         success_status = instance_double(Process::Status, success?: true)

--- a/spec/services/media_text_generation_service_spec.rb
+++ b/spec/services/media_text_generation_service_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe MediaTextGenerationService do
 
     context 'with a valid audio medium' do
       before do
-        allow(AudioTranscriptionService).to receive(:new).and_return(instance_double(AudioTranscriptionService, call: 'A generated transcript.'))
+        allow(AudioTranscriptionService).to receive(:new).and_return(
+          instance_double(AudioTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
+        )
       end
 
       it 'returns the generated transcript' do
@@ -58,7 +60,9 @@ RSpec.describe MediaTextGenerationService do
 
     context 'with a valid video medium' do
       before do
-        allow(VideoTranscriptionService).to receive(:new).and_return(instance_double(VideoTranscriptionService, call: 'A generated transcript.'))
+        allow(VideoTranscriptionService).to receive(:new).and_return(
+          instance_double(VideoTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
+        )
       end
 
       it 'returns the transcript generated from the video' do

--- a/spec/services/media_text_generation_service_spec.rb
+++ b/spec/services/media_text_generation_service_spec.rb
@@ -47,11 +47,14 @@ RSpec.describe MediaTextGenerationService do
     context 'with a valid audio medium' do
       before do
         allow(AudioTranscriptionService).to receive(:new).and_return(
-          instance_double(AudioTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
+          instance_double(AudioTranscriptionService, call: [
+            { 'text' => 'A generated', 'start_ms' => 0, 'end_ms' => 500 },
+            { 'text' => 'transcript.', 'start_ms' => 500, 'end_ms' => 1000 }
+          ])
         )
       end
 
-      it 'returns the generated transcript' do
+      it 'returns the transcript joined from the segments' do
         result = described_class.new(audio_medium).call
 
         expect(result).to eq('A generated transcript.')
@@ -61,11 +64,14 @@ RSpec.describe MediaTextGenerationService do
     context 'with a valid video medium' do
       before do
         allow(VideoTranscriptionService).to receive(:new).and_return(
-          instance_double(VideoTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
+          instance_double(VideoTranscriptionService, call: [
+            { 'text' => 'A generated', 'start_ms' => 0, 'end_ms' => 500 },
+            { 'text' => 'transcript.', 'start_ms' => 500, 'end_ms' => 1000 }
+          ])
         )
       end
 
-      it 'returns the transcript generated from the video' do
+      it 'returns the transcript joined from the segments' do
         result = described_class.new(video_medium).call
 
         expect(result).to eq('A generated transcript.')

--- a/spec/services/video_transcription_service_spec.rb
+++ b/spec/services/video_transcription_service_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe VideoTranscriptionService do
         end
         allow(AudioTranscriptionService).to receive(:new) do |audio_path|
           expect(audio_path).to end_with('.wav')
-          instance_double(AudioTranscriptionService, call: 'A generated transcript.')
+          instance_double(AudioTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
         end
       end
 
       it 'transcribes the audio extracted from the video' do
         result = described_class.new(video_path).call
-        expect(result).to eq('A generated transcript.')
+        expect(result).to eq({ text: 'A generated transcript.', segments: [] })
       end
     end
 

--- a/spec/services/video_transcription_service_spec.rb
+++ b/spec/services/video_transcription_service_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe VideoTranscriptionService do
         end
         allow(AudioTranscriptionService).to receive(:new) do |audio_path|
           expect(audio_path).to end_with('.wav')
-          instance_double(AudioTranscriptionService, call: { text: 'A generated transcript.', segments: [] })
+          instance_double(AudioTranscriptionService, call: [{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1000 }])
         end
       end
 
       it 'transcribes the audio extracted from the video' do
         result = described_class.new(video_path).call
-        expect(result).to eq({ text: 'A generated transcript.', segments: [] })
+        expect(result).to eq([{ 'text' => 'A generated transcript.', 'start_ms' => 0, 'end_ms' => 1000 }])
       end
     end
 


### PR DESCRIPTION
## 概要

- #299 から、`AudioTranscriptionService#call` の戻り値を、単なる文字列からセグメント単位のタイムスタンプ付き `{ text:, segments: }` に変更する修正を切り出しました。
  - 呼び出し側は全体の文字起こしテキストに加えて、各セグメントの開始/終了時刻も取得できるようになります。
- 各セグメントのオフセットは、音声の実際の長さ（`ffprobe` で取得）でクランプするようにしました。whisper-cliは各チャンクの最後のセグメントを、音声の実際の終端ではなく30秒の処理ウィンドウいっぱいまで埋めてしまうためです。
- `ffprobe` が失敗した場合・パース不能/非有限な長さを返した場合・`ffprobe` 自体がインストールされていない場合は、いずれもクランプ処理をスキップするだけとし、文字起こし全体は失敗させないようにしました。

## テスト
- 追加分を含む全てのspecがパスすることを確認しました。